### PR TITLE
Add User aggregate with Email and ExternalIdentity value objects

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: Unit Tests
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  test:
+  unit-tests:
     runs-on: ubuntu-latest
 
     steps:
@@ -24,5 +24,5 @@ jobs:
       - name: Build
         run: dotnet build src/PraxisNote.slnx --no-restore
 
-      - name: Test
+      - name: Run unit tests
         run: dotnet test src/PraxisNote.slnx --no-build --verbosity normal

--- a/README.md
+++ b/README.md
@@ -1,49 +1,40 @@
 # PraxisNote
 
-A note-first task management system designed for busy professionals.
+A note-first task management system. Write notes with checkboxes that automatically become tasks on a board, with bidirectional sync.
 
 ## Overview
 
-PraxisNote bridges the gap between free-form note-taking and structured task management. Write naturally in rich text notes, and any checkbox you create automatically becomes a trackable task on your board - with full bidirectional sync.
+PraxisNote bridges the gap between free-form note-taking and structured task management. Write naturally in rich text notes, and any checkbox you create automatically becomes a trackable task on your board.
 
 ### Key Features
 
-- **Note-First Workflow** - Capture thoughts in rich text notes using a TipTap editor
+- **Note-First Workflow** - Capture thoughts in rich text notes
 - **Automatic Task Extraction** - Checkboxes in notes become tasks on your board
 - **Bidirectional Sync** - Complete a task on the board, and the checkbox in your note is checked (and vice versa)
 - **Three-State Tasks** - Todo → In Progress → Done lifecycle with timestamps
-- **Label Organization** - Tag notes and tasks with shared labels; tasks inherit labels from their source note
-- **Google OAuth** - Simple authentication with your Google account
+- **Label Organization** - Tag notes and tasks; tasks inherit labels from their source note
 
-## Domain Model
+## Tech Stack
 
-| Aggregate | Purpose |
-|-----------|---------|
-| **User** | Authentication & ownership scoping |
-| **Note** | Rich text content with embedded checkboxes |
-| **Task** | Actionable items with status lifecycle |
-| **Label** | Cross-cutting organization tags |
+- .NET 10, C# (nullable reference types, implicit usings)
+- xUnit for testing
+- DDD (Domain-Driven Design)
 
 ## Project Structure
 
 ```
 src/
-├── PraxisNote.slnx              # .NET 10 solution
-└── PraxisNote.Domain/           # Pure domain model (no dependencies)
+├── PraxisNote.Domain/           # Pure domain model
+│   ├── Aggregates/              # User, Label (Note, Task coming soon)
+│   ├── ValueObjects/            # Email, ExternalIdentity
+│   ├── Common/                  # Entity, AggregateRoot, ValueObject
+│   └── Events/                  # IDomainEvent, DomainEventBase
+└── PraxisNote.Domain.Tests/     # Unit tests
 ```
-
-## Tech Stack
-
-- .NET 10
-- C# with nullable reference types enabled
 
 ## Getting Started
 
 ```bash
-cd src
-dotnet build PraxisNote.slnx
+dotnet build src/PraxisNote.slnx
+dotnet test src/PraxisNote.slnx
 ```
-
-## License
-
-[MIT](LICENSE)

--- a/src/PraxisNote.Domain.Tests/Aggregates/UserTests.cs
+++ b/src/PraxisNote.Domain.Tests/Aggregates/UserTests.cs
@@ -1,0 +1,120 @@
+using PraxisNote.Domain.Aggregates.Users;
+using PraxisNote.Domain.ValueObjects;
+
+namespace PraxisNote.Domain.Tests.Aggregates;
+
+public class UserTests
+{
+    private readonly ExternalIdentity _validExternalIdentity = new("Google", "oauth-123");
+    private readonly Email _validEmail = new("test@example.com");
+    private readonly string _validName = "Test User";
+
+    [Fact]
+    public void Register_WithValidInputs_ReturnsUserWithCorrectProperties()
+    {
+        // Act
+        var user = User.Register(_validExternalIdentity, _validEmail, _validName);
+
+        // Assert
+        Assert.NotEqual(Guid.Empty, user.Id);
+        Assert.Equal(_validExternalIdentity, user.ExternalIdentity);
+        Assert.Equal(_validEmail, user.Email);
+        Assert.Equal(_validName, user.Name);
+        Assert.Null(user.AvatarUrl);
+        Assert.True(user.CreatedAt <= DateTimeOffset.UtcNow);
+        Assert.True(user.LastLoginAt <= DateTimeOffset.UtcNow);
+    }
+
+    [Fact]
+    public void Register_WithAvatarUrl_SetsAvatarUrl()
+    {
+        // Arrange
+        var avatarUrl = "https://example.com/avatar.jpg";
+
+        // Act
+        var user = User.Register(_validExternalIdentity, _validEmail, _validName, avatarUrl);
+
+        // Assert
+        Assert.Equal(avatarUrl, user.AvatarUrl);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Register_WithEmptyOrWhitespaceAvatarUrl_SetsAvatarUrlToNull(string emptyAvatarUrl)
+    {
+        // Act
+        var user = User.Register(_validExternalIdentity, _validEmail, _validName, emptyAvatarUrl);
+
+        // Assert
+        Assert.Null(user.AvatarUrl);
+    }
+
+    [Fact]
+    public void Register_WithNullExternalIdentity_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => User.Register(null!, _validEmail, _validName));
+    }
+
+    [Fact]
+    public void Register_WithNullEmail_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => User.Register(_validExternalIdentity, null!, _validName));
+    }
+
+    [Fact]
+    public void Register_WithNullName_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => User.Register(_validExternalIdentity, _validEmail, null!));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Register_WithEmptyOrWhitespaceName_ThrowsArgumentException(string invalidName)
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => User.Register(_validExternalIdentity, _validEmail, invalidName));
+    }
+
+    [Fact]
+    public void Register_SetsCreatedAtAndLastLoginAtToSameTime()
+    {
+        // Act
+        var user = User.Register(_validExternalIdentity, _validEmail, _validName);
+
+        // Assert
+        Assert.Equal(user.CreatedAt, user.LastLoginAt);
+    }
+
+    [Fact]
+    public void RecordLogin_UpdatesLastLoginAt()
+    {
+        // Arrange
+        var user = User.Register(_validExternalIdentity, _validEmail, _validName);
+        var originalLoginAt = user.LastLoginAt;
+
+        // Act
+        user.RecordLogin();
+
+        // Assert
+        Assert.True(user.LastLoginAt >= originalLoginAt);
+    }
+
+    [Fact]
+    public void RecordLogin_DoesNotChangeCreatedAt()
+    {
+        // Arrange
+        var user = User.Register(_validExternalIdentity, _validEmail, _validName);
+        var originalCreatedAt = user.CreatedAt;
+
+        // Act
+        user.RecordLogin();
+
+        // Assert
+        Assert.Equal(originalCreatedAt, user.CreatedAt);
+    }
+}

--- a/src/PraxisNote.Domain.Tests/ValueObjects/EmailTests.cs
+++ b/src/PraxisNote.Domain.Tests/ValueObjects/EmailTests.cs
@@ -1,0 +1,91 @@
+using PraxisNote.Domain.ValueObjects;
+
+namespace PraxisNote.Domain.Tests.ValueObjects;
+
+public class EmailTests
+{
+    [Theory]
+    [InlineData("test@example.com")]
+    [InlineData("user.name@domain.org")]
+    [InlineData("user+tag@example.co.uk")]
+    public void Constructor_WithValidEmail_CreatesEmail(string validEmail)
+    {
+        // Act
+        var email = new Email(validEmail);
+
+        // Assert
+        Assert.Equal(validEmail.ToLowerInvariant(), email.Value);
+    }
+
+    [Fact]
+    public void Constructor_WithNullEmail_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => new Email(null!));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Constructor_WithEmptyOrWhitespaceEmail_ThrowsArgumentException(string invalidEmail)
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => new Email(invalidEmail));
+    }
+
+    [Theory]
+    [InlineData("notanemail")]
+    [InlineData("missing@")]
+    [InlineData("@nodomain.com")]
+    [InlineData("spaces in@email.com")]
+    public void Constructor_WithInvalidFormat_ThrowsArgumentException(string invalidEmail)
+    {
+        // Act & Assert
+        var ex = Assert.Throws<ArgumentException>(() => new Email(invalidEmail));
+        Assert.Contains("Invalid email format", ex.Message);
+    }
+
+    [Fact]
+    public void Value_IsStoredAsLowercase()
+    {
+        // Arrange
+        var mixedCaseEmail = "Test.User@Example.COM";
+
+        // Act
+        var email = new Email(mixedCaseEmail);
+
+        // Assert
+        Assert.Equal("test.user@example.com", email.Value);
+    }
+
+    [Fact]
+    public void Equality_IsCaseInsensitive()
+    {
+        // Arrange
+        var email1 = new Email("Test@Example.com");
+        var email2 = new Email("test@example.com");
+
+        // Act & Assert
+        Assert.Equal(email1, email2);
+    }
+
+    [Fact]
+    public void ToString_ReturnsLowercaseEmailAddress()
+    {
+        // Arrange
+        var email = new Email("Test@Example.COM");
+
+        // Act & Assert
+        Assert.Equal("test@example.com", email.ToString());
+    }
+
+    [Fact]
+    public void Constructor_TrimsWhitespaceFromEmail()
+    {
+        // Arrange & Act
+        var email = new Email("  test@example.com  ");
+
+        // Assert
+        Assert.Equal("test@example.com", email.Value);
+    }
+}

--- a/src/PraxisNote.Domain.Tests/ValueObjects/ExternalIdentityTests.cs
+++ b/src/PraxisNote.Domain.Tests/ValueObjects/ExternalIdentityTests.cs
@@ -1,0 +1,124 @@
+using PraxisNote.Domain.ValueObjects;
+
+namespace PraxisNote.Domain.Tests.ValueObjects;
+
+public class ExternalIdentityTests
+{
+    [Fact]
+    public void Constructor_WithValidInputs_CreatesExternalIdentity()
+    {
+        // Act
+        var identity = new ExternalIdentity("Google", "123456");
+
+        // Assert
+        Assert.Equal("google", identity.Provider);
+        Assert.Equal("123456", identity.ProviderId);
+    }
+
+    [Fact]
+    public void Constructor_NormalizesProviderToLowercase()
+    {
+        // Act
+        var identity = new ExternalIdentity("GOOGLE", "123456");
+
+        // Assert
+        Assert.Equal("google", identity.Provider);
+    }
+
+    [Fact]
+    public void Equality_ProviderIsCaseInsensitive()
+    {
+        // Arrange
+        var identity1 = new ExternalIdentity("Google", "123456");
+        var identity2 = new ExternalIdentity("GOOGLE", "123456");
+
+        // Act & Assert
+        Assert.Equal(identity1, identity2);
+    }
+
+    [Fact]
+    public void Constructor_TrimsWhitespaceFromProviderAndProviderId()
+    {
+        // Act
+        var identity = new ExternalIdentity("  Google  ", "  123456  ");
+
+        // Assert
+        Assert.Equal("google", identity.Provider);
+        Assert.Equal("123456", identity.ProviderId);
+    }
+
+    [Fact]
+    public void Constructor_WithNullProvider_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => new ExternalIdentity(null!, "123456"));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Constructor_WithEmptyOrWhitespaceProvider_ThrowsArgumentException(string invalidProvider)
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => new ExternalIdentity(invalidProvider, "123456"));
+    }
+
+    [Fact]
+    public void Constructor_WithNullProviderId_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => new ExternalIdentity("Google", null!));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Constructor_WithEmptyOrWhitespaceProviderId_ThrowsArgumentException(string invalidProviderId)
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => new ExternalIdentity("Google", invalidProviderId));
+    }
+
+    [Fact]
+    public void Equality_SameProviderAndId_AreEqual()
+    {
+        // Arrange
+        var identity1 = new ExternalIdentity("Google", "123456");
+        var identity2 = new ExternalIdentity("Google", "123456");
+
+        // Act & Assert
+        Assert.Equal(identity1, identity2);
+    }
+
+    [Fact]
+    public void Equality_DifferentProvider_AreNotEqual()
+    {
+        // Arrange
+        var identity1 = new ExternalIdentity("Google", "123456");
+        var identity2 = new ExternalIdentity("Microsoft", "123456");
+
+        // Act & Assert
+        Assert.NotEqual(identity1, identity2);
+    }
+
+    [Fact]
+    public void Equality_DifferentProviderId_AreNotEqual()
+    {
+        // Arrange
+        var identity1 = new ExternalIdentity("Google", "123456");
+        var identity2 = new ExternalIdentity("Google", "789012");
+
+        // Act & Assert
+        Assert.NotEqual(identity1, identity2);
+    }
+
+    [Fact]
+    public void ToString_ReturnsLowercaseProviderColonProviderId()
+    {
+        // Arrange
+        var identity = new ExternalIdentity("Google", "123456");
+
+        // Act & Assert
+        Assert.Equal("google:123456", identity.ToString());
+    }
+}

--- a/src/PraxisNote.Domain/Aggregates/Users/User.cs
+++ b/src/PraxisNote.Domain/Aggregates/Users/User.cs
@@ -1,0 +1,83 @@
+using PraxisNote.Domain.Common;
+using PraxisNote.Domain.ValueObjects;
+
+namespace PraxisNote.Domain.Aggregates.Users;
+
+/// <summary>
+/// User aggregate - represents an authenticated user who owns
+/// all notes, tasks, and labels in the system.
+/// </summary>
+public sealed class User : AggregateRoot
+{
+    /// <summary>
+    /// The external OAuth provider identity. Immutable after creation.
+    /// </summary>
+    public ExternalIdentity ExternalIdentity { get; private init; } = null!;
+
+    /// <summary>
+    /// The user's email address.
+    /// </summary>
+    public Email Email { get; private init; } = null!;
+
+    /// <summary>
+    /// The user's display name.
+    /// </summary>
+    public string Name { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// URL to the user's avatar image from the external OAuth provider. May be null.
+    /// </summary>
+    public string? AvatarUrl { get; private set; }
+
+    /// <summary>
+    /// When this user account was created.
+    /// </summary>
+    public DateTimeOffset CreatedAt { get; private init; }
+
+    /// <summary>
+    /// When the user last logged in.
+    /// </summary>
+    public DateTimeOffset LastLoginAt { get; private set; }
+
+    /// <summary>
+    /// Required for EF Core.
+    /// </summary>
+    private User() { }
+
+    private User(Guid id, ExternalIdentity externalIdentity, Email email, string name, string? avatarUrl) : base(id)
+    {
+        ArgumentNullException.ThrowIfNull(externalIdentity);
+        ArgumentNullException.ThrowIfNull(email);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+        var now = DateTimeOffset.UtcNow;
+
+        ExternalIdentity = externalIdentity;
+        Email = email;
+        Name = name;
+        AvatarUrl = string.IsNullOrWhiteSpace(avatarUrl) ? null : avatarUrl;
+        CreatedAt = now;
+        LastLoginAt = now;
+    }
+
+    /// <summary>
+    /// Registers a new user from an external OAuth provider.
+    /// </summary>
+    /// <param name="externalIdentity">The external OAuth provider identity.</param>
+    /// <param name="email">The user's email address.</param>
+    /// <param name="name">The user's display name.</param>
+    /// <param name="avatarUrl">Optional URL to the user's avatar.</param>
+    /// <returns>A new User instance.</returns>
+    public static User Register(ExternalIdentity externalIdentity, Email email, string name, string? avatarUrl = null)
+    {
+        return new User(Guid.NewGuid(), externalIdentity, email, name, avatarUrl);
+    }
+
+    /// <summary>
+    /// Records that the user has logged in, updating the last login timestamp.
+    /// </summary>
+    public void RecordLogin()
+    {
+        LastLoginAt = DateTimeOffset.UtcNow;
+    }
+}

--- a/src/PraxisNote.Domain/ValueObjects/Email.cs
+++ b/src/PraxisNote.Domain/ValueObjects/Email.cs
@@ -1,0 +1,45 @@
+using System.Net.Mail;
+using PraxisNote.Domain.Common;
+
+namespace PraxisNote.Domain.ValueObjects;
+
+/// <summary>
+/// Represents a validated email address.
+/// Stored in lowercase for case-insensitive equality.
+/// </summary>
+public sealed record Email : ValueObject
+{
+    public string Value { get; }
+
+    public Email(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+
+        var trimmed = value.Trim();
+        if (!IsValidEmail(trimmed))
+        {
+            throw new ArgumentException("Invalid email format.", nameof(value));
+        }
+
+        Value = trimmed.ToLowerInvariant();
+    }
+
+    private static bool IsValidEmail(string email)
+    {
+        try
+        {
+            var mailAddress = new MailAddress(email);
+            return mailAddress.Address == email.Trim();
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+    }
+
+    public override string ToString() => Value;
+}

--- a/src/PraxisNote.Domain/ValueObjects/ExternalIdentity.cs
+++ b/src/PraxisNote.Domain/ValueObjects/ExternalIdentity.cs
@@ -1,0 +1,31 @@
+using PraxisNote.Domain.Common;
+
+namespace PraxisNote.Domain.ValueObjects;
+
+/// <summary>
+/// Represents an external OAuth provider identity.
+/// Uniqueness is determined by the combination of Provider and ProviderId.
+/// </summary>
+public sealed record ExternalIdentity : ValueObject
+{
+    /// <summary>
+    /// The OAuth provider name (e.g., "Google", "Microsoft", "GitHub").
+    /// </summary>
+    public string Provider { get; }
+
+    /// <summary>
+    /// The unique identifier from the OAuth provider.
+    /// </summary>
+    public string ProviderId { get; }
+
+    public ExternalIdentity(string provider, string providerId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(provider);
+        ArgumentException.ThrowIfNullOrWhiteSpace(providerId);
+
+        Provider = provider.Trim().ToLowerInvariant();
+        ProviderId = providerId.Trim();
+    }
+
+    public override string ToString() => $"{Provider}:{ProviderId}";
+}


### PR DESCRIPTION
## Summary

- Add `Email` value object with format validation and case-insensitive equality
- Add `ExternalIdentity` value object for provider-agnostic OAuth
- Add `User` aggregate with `Register` factory and `RecordLogin` behavior
- Update README to reflect current implementation
- Rename GitHub Action to "Unit Tests"

## Test plan

- [x] All 43 unit tests pass
- [x] Solution builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)