### PR TITLE
Fix InProgress time display for tasks without startedAt

### DIFF
--- a/src/PraxisNote.Web/ClientApp/src/app/tasks/task-card.component.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/tasks/task-card.component.ts
@@ -106,8 +106,10 @@ export class TaskCardComponent {
 
   readonly relativeTime = computed(() => {
     const task = this.task();
-    if (task.status === 'InProgress' && task.startedAt) {
-      return this.formatElapsedTime(task.startedAt);
+    if (task.status === 'InProgress') {
+      // Use startedAt if available, fall back to createdAt for older tasks
+      const startTime = task.startedAt ?? task.createdAt;
+      return this.formatElapsedTime(startTime);
     }
     if (task.status === 'Done' && task.completedAt) {
       return this.formatRelativeTime(task.completedAt);


### PR DESCRIPTION
## Summary

- Use `createdAt` as fallback for InProgress tasks that don't have `startedAt`
- Fixes issue where older tasks created before the startedAt feature was added show no time indicator

## Test plan
- [x] Build succeeds
- [ ] Verify older InProgress tasks now show elapsed time based on createdAt

🤖 Generated with [Claude Code](https://claude.com/claude-code)