### PR TITLE
Remove createdAt fallback for InProgress time display

### DIFF
--- a/src/PraxisNote.Web/ClientApp/src/app/tasks/task-card.component.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/tasks/task-card.component.ts
@@ -106,10 +106,8 @@ export class TaskCardComponent {
 
   readonly relativeTime = computed(() => {
     const task = this.task();
-    if (task.status === 'InProgress') {
-      // Use startedAt if available, fall back to createdAt for older tasks
-      const startTime = task.startedAt ?? task.createdAt;
-      return this.formatElapsedTime(startTime);
+    if (task.status === 'InProgress' && task.startedAt) {
+      return this.formatElapsedTime(task.startedAt);
     }
     if (task.status === 'Done' && task.completedAt) {
       return this.formatRelativeTime(task.completedAt);


### PR DESCRIPTION
## Summary

- Reverts the createdAt fallback for InProgress tasks
- Only shows time indicator for tasks with a real `startedAt` value
- Old tasks without `startedAt` will show no time (cleaner than showing same time for all)

## Test plan
- [x] Build succeeds
- [ ] Verify old InProgress tasks show no time indicator
- [ ] Verify newly dragged InProgress tasks show elapsed time

🤖 Generated with [Claude Code](https://claude.com/claude-code)