### PR TITLE
Run database migrations on startup in all environments

### DIFF
--- a/src/PraxisNote.Web/Program.cs
+++ b/src/PraxisNote.Web/Program.cs
@@ -112,10 +112,9 @@ var app = builder.Build();
 // Use forwarded headers (must be first - for Cloud Run / load balancers)
 app.UseForwardedHeaders();
 
-// Apply database migrations (Development and E2E only)
-if (app.Environment.IsDevelopment() || app.Environment.EnvironmentName == "E2E")
+// Apply database migrations on startup (safe for single-instance Cloud Run)
+using (var scope = app.Services.CreateScope())
 {
-    using var scope = app.Services.CreateScope();
     var db = scope.ServiceProvider.GetRequiredService<PraxisNoteDbContext>();
     db.Database.Migrate();
 }


### PR DESCRIPTION
## Summary

- Removes the Development/E2E environment check for running migrations
- Migrations now run in Production on Cloud Run startup
- Fixes "relation Users does not exist" error in production

## Why

Single-instance Cloud Run deployments can safely run migrations on startup. This ensures the database schema is always up to date after deployment.

## Test plan
- [x] Local build succeeds
- [ ] E2E tests pass
- [ ] Production deployment creates database tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)