### PR TITLE
Fix session timeout redirect and drag-drop to empty columns

### DIFF
--- a/src/PraxisNote.Web/ClientApp/src/app/app.config.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/app.config.ts
@@ -7,6 +7,7 @@ import { definePreset } from '@primeng/themes';
 import Aura from '@primeng/themes/aura';
 import { routes } from './app.routes';
 import { mockAuthInterceptor } from './auth/mock-auth.interceptor';
+import { authInterceptor } from './auth/auth.interceptor';
 
 const PraxisNoteTheme = definePreset(Aura, {
   semantic: {
@@ -31,7 +32,7 @@ export const appConfig: ApplicationConfig = {
     provideZonelessChangeDetection(),
     provideBrowserGlobalErrorListeners(),
     provideRouter(routes),
-    provideHttpClient(withInterceptors([mockAuthInterceptor])),
+    provideHttpClient(withInterceptors([mockAuthInterceptor, authInterceptor])),
     provideAnimationsAsync(),
     providePrimeNG({
       theme: {

--- a/src/PraxisNote.Web/ClientApp/src/app/auth/auth.interceptor.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/auth/auth.interceptor.ts
@@ -1,0 +1,20 @@
+import { HttpInterceptorFn } from '@angular/common/http';
+import { inject } from '@angular/core';
+import { Router } from '@angular/router';
+import { catchError, throwError } from 'rxjs';
+
+export const authInterceptor: HttpInterceptorFn = (req, next) => {
+  const router = inject(Router);
+
+  return next(req).pipe(
+    catchError((error) => {
+      if (error.status === 401 && !req.url.includes('/api/auth/me')) {
+        // Session expired - redirect to home which will show login
+        router.navigate(['/']);
+        // Force page reload to reset app state
+        window.location.href = '/';
+      }
+      return throwError(() => error);
+    })
+  );
+};

--- a/src/PraxisNote.Web/ClientApp/src/app/tasks/tasks.page.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/tasks/tasks.page.ts
@@ -35,7 +35,7 @@ type TaskStatus = 'Todo' | 'InProgress' | 'Done';
         <!-- Kanban Board -->
         <div class="grid grid-cols-1 md:grid-cols-3 gap-4 md:gap-6">
           <!-- Todo Column -->
-          <div class="rounded-lg p-3 min-h-48 transition-all bg-todo">
+          <div class="flex flex-col rounded-lg p-3 min-h-48 transition-all bg-todo">
             <div class="flex items-center justify-between mb-3">
               <div class="flex items-center gap-2">
                 <span class="text-xs font-medium text-todo-foreground uppercase tracking-wide">Todo</span>
@@ -57,7 +57,7 @@ type TaskStatus = 'Todo' | 'InProgress' | 'Done';
               [cdkDropListData]="taskService.todoTasks()"
               [cdkDropListConnectedTo]="[inProgressList, doneList]"
               (cdkDropListDropped)="drop($event, 'Todo')"
-              class="space-y-2 min-h-12"
+              class="flex-1 space-y-2 min-h-12"
             >
               <!-- Inline task creation -->
               @if (inlineCreatingColumn() === 'Todo') {
@@ -94,7 +94,7 @@ type TaskStatus = 'Todo' | 'InProgress' | 'Done';
           </div>
 
           <!-- In Progress Column -->
-          <div class="rounded-lg p-3 min-h-48 transition-all bg-inprogress">
+          <div class="flex flex-col rounded-lg p-3 min-h-48 transition-all bg-inprogress">
             <div class="flex items-center justify-between mb-3">
               <div class="flex items-center gap-2">
                 <span class="text-xs font-medium text-inprogress-foreground uppercase tracking-wide">In Progress</span>
@@ -116,7 +116,7 @@ type TaskStatus = 'Todo' | 'InProgress' | 'Done';
               [cdkDropListData]="taskService.inProgressTasks()"
               [cdkDropListConnectedTo]="[todoList, doneList]"
               (cdkDropListDropped)="drop($event, 'InProgress')"
-              class="space-y-2 min-h-12"
+              class="flex-1 space-y-2 min-h-12"
             >
               <!-- Inline task creation -->
               @if (inlineCreatingColumn() === 'InProgress') {
@@ -152,7 +152,7 @@ type TaskStatus = 'Todo' | 'InProgress' | 'Done';
           </div>
 
           <!-- Done Column -->
-          <div class="rounded-lg p-3 min-h-48 transition-all bg-done">
+          <div class="flex flex-col rounded-lg p-3 min-h-48 transition-all bg-done">
             <div class="flex items-center gap-2 mb-3">
               <span class="text-xs font-medium text-done-foreground uppercase tracking-wide">Done</span>
               <span class="text-xs text-done-foreground-muted">{{ taskService.doneTasks().length }}</span>
@@ -163,7 +163,7 @@ type TaskStatus = 'Todo' | 'InProgress' | 'Done';
               [cdkDropListData]="taskService.doneTasks()"
               [cdkDropListConnectedTo]="[todoList, inProgressList]"
               (cdkDropListDropped)="drop($event, 'Done')"
-              class="space-y-2 min-h-12"
+              class="flex-1 space-y-2 min-h-12"
             >
               @for (task of taskService.doneTasks(); track task.id) {
                 <div cdkDrag [cdkDragData]="task" class="cursor-grab active:cursor-grabbing touch-manipulation">


### PR DESCRIPTION
## Summary

Fixes two bugs reported by user testing.

### Session Timeout (#33)
- Add HTTP interceptor to catch 401 errors and redirect to login page
- Cookie is already configured for 30 days with sliding expiration

### Drag-Drop (#34)
- Make column containers use flex column layout
- Add `flex-1` to drop lists so they expand to fill available column space
- Users can now drop tasks anywhere in the column, not just on existing tasks

## Test Plan
- [ ] Session expiry redirects to login (hard to test without waiting)
- [ ] Can drop tasks onto empty space below existing tasks in any column

Fixes #33, Fixes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)