### PR TITLE
Fix column background colors not showing for Todo/InProgress

### DIFF
--- a/src/PraxisNote.Web/ClientApp/src/app/tasks/column.component.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/tasks/column.component.ts
@@ -16,7 +16,11 @@ type TaskStatus = 'Todo' | 'InProgress' | 'Done';
   template: `
     <div
       class="flex flex-col rounded-lg p-3 min-h-48 transition-all"
-      [ngClass]="status() | statusColor:'bg'"
+      [ngClass]="{
+        'bg-todo': status() === 'Todo',
+        'bg-inprogress': status() === 'InProgress',
+        'bg-done': status() === 'Done'
+      }"
     >
       <div class="flex items-center justify-between mb-3">
         <div class="flex items-center gap-2">


### PR DESCRIPTION
## Summary

- Fix Todo and InProgress columns showing white/transparent instead of their background colors
- Root cause: Tailwind v4 content scanner couldn't detect dynamically constructed class names from StatusColorPipe (`bg-todo`, `bg-inprogress`)
- Solution: Replace pipe usage with explicit ngClass bindings

## Changes

Replace:
```html
[ngClass]="status() | statusColor:'bg'"
```

With:
```html
[ngClass]="{
  'bg-todo': status() === 'Todo',
  'bg-inprogress': status() === 'InProgress',
  'bg-done': status() === 'Done'
}"
```

## Test plan

- [x] Build succeeds
- [ ] Verify column backgrounds display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)