### PR TITLE
Add project-level nuget.config to fix local E2E tests

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
## Summary

- Add `nuget.config` at project root to ensure consistent NuGet behavior
- Clears inherited package sources and uses only nuget.org
- Fixes local E2E test failures caused by private feeds in global NuGet config

## Problem

Developers with private NuGet feeds (e.g., Azure DevOps) in their global `~/.nuget/NuGet/NuGet.Config` experience authentication failures when running E2E tests locally:

```
error NU1301: Unable to load the service index for source https://pkgs.dev.azure.com/...
Response status code does not indicate success: 401 (Unauthorized)
```

## Solution

Project-level `nuget.config` with `<clear />` directive:
```xml
<packageSources>
  <clear />
  <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
</packageSources>
```

## Test plan

- [x] `dotnet restore` works without auth errors
- [x] `dotnet ef migrations list` works
- [x] E2E tests run locally (8 passed, 4 failed - test issues, not infra)
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)