### PR TITLE
Fix E2E test race condition in seedTestUser

### DIFF
--- a/tests/PraxisNote.E2E.Tests/helpers/db-reset.ts
+++ b/tests/PraxisNote.E2E.Tests/helpers/db-reset.ts
@@ -32,30 +32,24 @@ export async function seedTestUser(): Promise<{ userId: string; email: string; n
     const email = 'e2e-test@example.com';
     const name = 'E2E Test User';
 
-    // Check if user exists, if not create
-    const result = await client.query(
-      `SELECT "Id" FROM "Users" WHERE "Id" = $1`,
-      [userId]
+    // Use upsert to handle parallel test execution safely
+    await client.query(
+      `
+      INSERT INTO "Users" (
+        "Id",
+        "ExternalIdentity_Provider",
+        "ExternalIdentity_ProviderId",
+        "Email_Value",
+        "Name",
+        "AvatarUrl",
+        "CreatedAt",
+        "LastLoginAt"
+      )
+      VALUES ($1::uuid, 'MockAuth', $2, $3, $4, NULL, NOW(), NOW())
+      ON CONFLICT ("Id") DO NOTHING
+      `,
+      [userId, userId, email, name]
     );
-
-    if (result.rows.length === 0) {
-      await client.query(
-        `
-        INSERT INTO "Users" (
-          "Id",
-          "ExternalIdentity_Provider",
-          "ExternalIdentity_ProviderId",
-          "Email_Value",
-          "Name",
-          "AvatarUrl",
-          "CreatedAt",
-          "LastLoginAt"
-        )
-        VALUES ($1::uuid, 'MockAuth', $2, $3, $4, NULL, NOW(), NOW())
-        `,
-        [userId, userId, email, name]
-      );
-    }
 
     return { userId, email, name };
   } finally {


### PR DESCRIPTION
## Summary

- Fix flaky E2E test failure caused by race condition in parallel test execution
- `seedTestUser()` was using SELECT-then-INSERT which isn't atomic
- Multiple workers calling simultaneously caused duplicate key violations

## Root Cause

With 6 parallel workers:
1. Worker A: SELECT (no user found)
2. Worker B: SELECT (no user found)  
3. Worker A: INSERT (succeeds)
4. Worker B: INSERT (fails - duplicate key)

## Solution

Use PostgreSQL's atomic upsert:
```sql
INSERT INTO "Users" (...) VALUES (...)
ON CONFLICT ("Id") DO NOTHING
```

## Test plan

- [x] All 12 E2E tests pass locally
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)