### PR TITLE
Add dynamic status badges and code coverage to README

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,6 +1,8 @@
 name: E2E Tests
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
   workflow_call: # Allow other workflows to call this one
@@ -117,11 +119,38 @@ jobs:
           Authentication__Google__ClientSecret: "dummy-for-e2e"
 
       - name: Run E2E tests
-        run: npm test -- --reporter=github
+        id: e2e
+        run: PLAYWRIGHT_JSON_OUTPUT_NAME=results.json npm test -- --reporter=github --reporter=json
         working-directory: tests/PraxisNote.E2E.Tests
         env:
           BASE_URL: "http://localhost:5002"
           CI: true
+
+      - name: Parse E2E test results
+        id: parse
+        if: always()
+        working-directory: tests/PraxisNote.E2E.Tests
+        run: |
+          if [ -f "results.json" ]; then
+            # Parse Playwright JSON output
+            PASSED=$(jq '.stats.expected // 0' results.json)
+            echo "passed=$PASSED" >> $GITHUB_OUTPUT
+          else
+            # Fallback: count test files
+            TEST_COUNT=$(find . -name "*.spec.ts" -exec grep -l "test(" {} \; | wc -l)
+            echo "passed=$TEST_COUNT" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Update E2E tests badge
+        if: github.ref == 'refs/heads/main' && always()
+        uses: schneegans/dynamic-badges-action@v1.7.0
+        with:
+          auth: ${{ secrets.GIST_TOKEN }}
+          gistID: 093c03c9b23736d0600e9eeb2e772063
+          filename: e2e-tests.json
+          label: E2E Tests
+          message: ${{ steps.parse.outputs.passed }} passing
+          color: ${{ steps.e2e.outcome == 'success' && 'brightgreen' || 'red' }}
 
       - name: Upload test results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,8 @@
 name: Unit Tests
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
   workflow_call: # Allow other workflows to call this one
@@ -23,5 +25,58 @@ jobs:
       - name: Build
         run: dotnet build src/PraxisNote.slnx --no-restore
 
-      - name: Run unit tests
-        run: dotnet test src/PraxisNote.slnx --no-build --verbosity normal
+      - name: Run unit tests with coverage
+        id: test
+        run: |
+          dotnet test src/PraxisNote.slnx --no-build --verbosity normal \
+            --collect:"XPlat Code Coverage" \
+            --results-directory ./coverage \
+            --logger "trx;LogFileName=test-results.trx"
+
+      - name: Parse test results
+        id: parse
+        if: always()
+        run: |
+          # Extract test count from TRX file
+          TRX_FILE=$(find ./coverage -name "*.trx" -type f | head -1)
+          if [ -f "$TRX_FILE" ]; then
+            TEST_COUNT=$(grep -oP 'total="\K\d+' "$TRX_FILE" | head -1)
+            PASSED=$(grep -oP 'passed="\K\d+' "$TRX_FILE" | head -1)
+            echo "test_count=$TEST_COUNT" >> $GITHUB_OUTPUT
+            echo "passed=$PASSED" >> $GITHUB_OUTPUT
+          else
+            echo "test_count=0" >> $GITHUB_OUTPUT
+            echo "passed=0" >> $GITHUB_OUTPUT
+          fi
+
+          # Extract coverage percentage from Cobertura XML
+          COV_FILE=$(find ./coverage -name "coverage.cobertura.xml" -type f | head -1)
+          if [ -f "$COV_FILE" ]; then
+            LINE_RATE=$(grep -oP 'line-rate="\K[0-9.]+' "$COV_FILE" | head -1)
+            PERCENT=$(echo "$LINE_RATE * 100" | bc -l | xargs printf "%.1f")
+            echo "coverage=$PERCENT" >> $GITHUB_OUTPUT
+          else
+            echo "coverage=0" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Update unit tests badge
+        if: github.ref == 'refs/heads/main' && always()
+        uses: schneegans/dynamic-badges-action@v1.7.0
+        with:
+          auth: ${{ secrets.GIST_TOKEN }}
+          gistID: 093c03c9b23736d0600e9eeb2e772063
+          filename: unit-tests.json
+          label: Unit Tests
+          message: ${{ steps.parse.outputs.passed }} passing
+          color: ${{ steps.test.outcome == 'success' && 'brightgreen' || 'red' }}
+
+      - name: Update coverage badge
+        if: github.ref == 'refs/heads/main' && always()
+        uses: schneegans/dynamic-badges-action@v1.7.0
+        with:
+          auth: ${{ secrets.GIST_TOKEN }}
+          gistID: 093c03c9b23736d0600e9eeb2e772063
+          filename: coverage.json
+          label: Coverage
+          message: ${{ steps.parse.outputs.coverage }}%
+          color: ${{ steps.parse.outputs.coverage > 80 && 'brightgreen' || steps.parse.outputs.coverage > 60 && 'yellow' || 'red' }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # PraxisNote
 
+[![Unit Tests](https://github.com/garethbaumgart/praxis-note/actions/workflows/tests.yml/badge.svg)](https://github.com/garethbaumgart/praxis-note/actions/workflows/tests.yml)
+[![E2E Tests](https://github.com/garethbaumgart/praxis-note/actions/workflows/e2e-tests.yml/badge.svg)](https://github.com/garethbaumgart/praxis-note/actions/workflows/e2e-tests.yml)
+[![Deploy](https://github.com/garethbaumgart/praxis-note/actions/workflows/deploy-cloud-run.yml/badge.svg?branch=main)](https://github.com/garethbaumgart/praxis-note/actions/workflows/deploy-cloud-run.yml)
+![Unit Tests](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/garethbaumgart/093c03c9b23736d0600e9eeb2e772063/raw/unit-tests.json)
+![E2E Tests](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/garethbaumgart/093c03c9b23736d0600e9eeb2e772063/raw/e2e-tests.json)
+![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/garethbaumgart/093c03c9b23736d0600e9eeb2e772063/raw/coverage.json)
+[![Last Commit](https://img.shields.io/github/last-commit/garethbaumgart/praxis-note)](https://github.com/garethbaumgart/praxis-note/commits/main)
+![.NET](https://img.shields.io/badge/.NET-10-512BD4)
+![Angular](https://img.shields.io/badge/Angular-21-DD0031)
+
 A task management system with a kanban board. Currently features drag-and-drop task management with three-state workflow (Todo → In Progress → Done).
 
 **Live:** https://praxisnote-kv77ni5hzq-ts.a.run.app
@@ -231,7 +241,7 @@ GitHub Actions runs automatically on every push to `main` and on pull requests:
 
 | Workflow | Trigger | What it does |
 |----------|---------|--------------|
-| **Unit Tests** | Push/PR | Runs `dotnet test` on Domain tests (200+ tests) |
+| **Unit Tests** | Push/PR | Runs `dotnet test` on Domain tests |
 | **E2E Tests** | Push/PR | Spins up PostgreSQL, runs migrations, starts the app, runs Playwright tests |
 | **Copilot Review** | PR only | AI-powered code review with suggestions |
 | **CodeRabbit Review** | PR only | AI-powered code review with detailed line-by-line feedback |
@@ -242,7 +252,7 @@ The E2E workflow:
 1. Starts a PostgreSQL service container (port 5433)
 2. Applies EF Core migrations to create the schema
 3. Builds and starts the .NET application in E2E mode
-4. Runs 12 Playwright smoke tests (auth, health, tasks, API access)
+4. Runs Playwright smoke tests (auth, health, tasks, API access)
 5. Uploads HTML test reports as artifacts on failure
 
 PRs require all tests to pass before merge.


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow badges (Unit Tests, E2E Tests, Deploy)
- Add dynamic test count badges that auto-update from CI runs using Gist + Shields.io
- Add code coverage badge using Coverlet
- Add last commit and .NET version badges
- Update workflows to collect coverage and parse test results
- Remove hardcoded test counts from README

## Changes

### Workflows
- `tests.yml`: Added coverage collection with Coverlet, TRX parsing for test counts, dynamic badge updates
- `e2e-tests.yml`: Added JSON reporter, test count parsing, dynamic badge update

### README
- Added 8 badges after title (3 status, 3 dynamic metrics, 2 static info)
- Removed hardcoded "200+" and "12" test counts

## Badge Preview

After merge, badges will show:
```
[Unit Tests: passing] [E2E Tests: passing] [Deploy: passing]
[Unit Tests: 201 passing] [E2E Tests: 12 passing] [Coverage: XX.X%]
[Last Commit: X hours ago] [.NET: 10]
```

## Test plan

- [x] Gist created with initial JSON files
- [x] GIST_TOKEN secret added to repository
- [ ] Unit tests pass (will also verify TRX parsing works)
- [ ] E2E tests pass (will also verify JSON reporter works)
- [ ] Badges update after merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced CI test reporting and result tracking, including parsing and fallback logic for test counts and coverage.
  * Automated badge updates on main for unit tests, coverage, and end-to-end test pass counts, reflecting parsed results and status.
  * Workflows now also run on pushes to main to improve visibility of test outcomes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->