### PR TITLE
Fix secrets not passed to reusable workflows

### DIFF
--- a/.github/workflows/deploy-cloud-run.yml
+++ b/.github/workflows/deploy-cloud-run.yml
@@ -14,9 +14,11 @@ env:
 jobs:
   unit-tests:
     uses: ./.github/workflows/tests.yml
+    secrets: inherit
 
   e2e-tests:
     uses: ./.github/workflows/e2e-tests.yml
+    secrets: inherit
 
   deploy:
     needs: [unit-tests, e2e-tests]


### PR DESCRIPTION
## Summary

Add `secrets: inherit` to workflow_call jobs so GIST_TOKEN is available when deploy workflow calls unit-tests and e2e-tests.

## Problem

Badge updates worked when workflows ran independently (on PR) but failed with 401 Unauthorized when called via `workflow_call` from the deploy workflow. This is because secrets aren't automatically passed to reusable workflows.

## Solution

Add `secrets: inherit` to both workflow calls in deploy-cloud-run.yml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflow configuration to enable secure secret propagation to test workflows, improving credential handling during the deployment pipeline.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->