### PR TITLE
Harmonize due date colors with column theme

### DIFF
--- a/src/PraxisNote.Web/ClientApp/src/app/tasks/date-picker-popover.component.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/tasks/date-picker-popover.component.ts
@@ -39,7 +39,7 @@ import { DatePicker } from 'primeng/datepicker';
           type="button"
           (click)="selectQuickOption('tomorrow'); $event.stopPropagation()"
           class="px-2 py-0.5 text-xs font-medium rounded-full transition-colors"
-          [class]="isSelected('tomorrow') ? 'bg-blue-200 text-blue-800' : 'bg-blue-100 text-blue-700 hover:bg-blue-200'"
+          [class]="isSelected('tomorrow') ? 'bg-amber-100 text-amber-700' : 'bg-amber-50 text-amber-600 hover:bg-amber-100'"
         >
           +1
         </button>
@@ -47,7 +47,7 @@ import { DatePicker } from 'primeng/datepicker';
           type="button"
           (click)="selectQuickOption('nextWeek'); $event.stopPropagation()"
           class="px-2 py-0.5 text-xs font-medium rounded-full transition-colors"
-          [class]="isSelected('nextWeek') ? 'bg-blue-200 text-blue-800' : 'bg-blue-100 text-blue-700 hover:bg-blue-200'"
+          [class]="isSelected('nextWeek') ? 'bg-slate-200 text-slate-700' : 'bg-slate-100 text-slate-600 hover:bg-slate-200'"
         >
           +7
         </button>

--- a/src/PraxisNote.Web/ClientApp/src/app/tasks/due-date-badge.component.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/tasks/due-date-badge.component.ts
@@ -87,12 +87,13 @@ export class DueDateBadgeComponent {
     const diff = this.daysDiff();
     if (diff === null) return '';
 
-    if (this.taskStatus() === 'Done') return 'text-foreground-muted/40 line-through';
-    if (diff < 0) return 'text-red-500 font-medium';
-    if (diff === 0) return 'text-amber-600';
-    if (diff === 1) return 'text-orange-500';
-    if (diff <= 6) return 'text-blue-500';
-    return 'text-foreground-muted/60';
+    // Option A: Warm urgency scale - red (overdue), amber (today/tomorrow), slate (future)
+    if (this.taskStatus() === 'Done') return 'bg-slate-100 text-slate-400 line-through';
+    if (diff < 0) return 'bg-red-100 text-red-600 font-medium';
+    if (diff === 0) return 'bg-amber-100 text-amber-700';
+    if (diff === 1) return 'bg-amber-50 text-amber-600';
+    if (diff <= 6) return 'bg-slate-100 text-slate-600';
+    return 'bg-slate-100 text-slate-500';
   });
 
   readonly iconClass = computed(() => {

--- a/tests/PraxisNote.E2E.Tests/smoke-tests/due-date.spec.ts
+++ b/tests/PraxisNote.E2E.Tests/smoke-tests/due-date.spec.ts
@@ -118,7 +118,7 @@ test.describe('Due Dates', () => {
     // Use button selector to avoid matching task title "Task due today"
     const dueDateButton = taskCard.locator('button').filter({ hasText: 'Today' });
     await expect(dueDateButton).toBeVisible();
-    await expect(dueDateButton).toHaveClass(/text-amber-600/);
+    await expect(dueDateButton).toHaveClass(/text-amber-700/);
   });
 
   test('displays overdue date with red styling and exclamation icon', async ({ page, request }) => {
@@ -146,7 +146,7 @@ test.describe('Due Dates', () => {
     // Class is on the button, not the span text inside
     const dueDateButton = taskCard.locator('button').filter({ hasText: 'Yesterday' });
     await expect(dueDateButton).toBeVisible();
-    await expect(dueDateButton).toHaveClass(/text-red-500/);
+    await expect(dueDateButton).toHaveClass(/text-red-600/);
     // Verify exclamation icon is present
     await expect(taskCard.locator('.pi-exclamation-circle')).toBeVisible();
   });


### PR DESCRIPTION
## Summary

Apply Option A (warm urgency scale) from the mockups to harmonize due date colors with the column theme (slate/sky/emerald).

## Before vs After

| State | Before | After |
|-------|--------|-------|
| Overdue | red-500 | red-100 bg, red-600 text |
| Today | amber-600 | amber-100 bg, amber-700 text |
| Tomorrow | orange-500 | amber-50 bg, amber-600 text |
| This week | blue-500 | slate-100 bg, slate-600 text |
| Future | muted | slate-100 bg, slate-500 text |

## Changes

- **due-date-badge.component.ts**: Updated `badgeClass` computed to use new color scheme with backgrounds
- **date-picker-popover.component.ts**: Updated quick option buttons (+1, +7) to match

## Benefits

- Reduced from 5 color hues to 3 (red, amber, slate)
- Warm colors (red/amber) for urgency, cool (slate) for non-urgent
- No more blue dates clashing with sky "In Progress" column
- Clear visual hierarchy: overdue > today > tomorrow > future

## Test plan

- [x] Unit tests pass (205/205)
- [x] Angular build succeeds
- [ ] Visual review of due date badges in all states
- [ ] Date picker quick options show correct colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined date-picker quick-option button colors to amber/slate palettes for better visual consistency.
  * Updated due-date badges to use background + text color combinations with clearer distinctions for overdue (stronger red), today (amber), tomorrow (lighter amber), and near/far future (slate tones).

* **Tests**
  * Updated end-to-end expectations to match the revised amber and red color intensities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->