### PR TITLE
Change archive threshold from 7 to 2 days, move to configuration

### DIFF
--- a/src/PraxisNote.Application/Features/Tasks/GetArchivedCount.cs
+++ b/src/PraxisNote.Application/Features/Tasks/GetArchivedCount.cs
@@ -1,16 +1,19 @@
+using Microsoft.Extensions.Options;
 using PraxisNote.Domain.Aggregates.Tasks;
 using TaskStatus = PraxisNote.Domain.ValueObjects.TaskStatus;
 
 namespace PraxisNote.Application.Features.Tasks;
 
-public sealed class GetArchivedCount(ITaskRepository taskRepository)
+public sealed class GetArchivedCount(ITaskRepository taskRepository, IOptions<TaskSettings> settings)
 {
+    private readonly TaskSettings _settings = settings.Value;
+
     public record Query(Guid UserId);
 
     public async Task<int> ExecuteAsync(Query query, CancellationToken cancellationToken = default)
     {
         var tasks = await taskRepository.GetByUserIdAsync(query.UserId, cancellationToken);
-        var archiveThreshold = DateTimeOffset.UtcNow.AddDays(-TaskConstants.ArchiveThresholdDays);
+        var archiveThreshold = DateTimeOffset.UtcNow.AddDays(-_settings.ArchiveThresholdDays);
 
         return tasks.Count(t =>
             t.Status == TaskStatus.Done

--- a/src/PraxisNote.Application/Features/Tasks/GetUserTasks.cs
+++ b/src/PraxisNote.Application/Features/Tasks/GetUserTasks.cs
@@ -1,16 +1,19 @@
+using Microsoft.Extensions.Options;
 using PraxisNote.Domain.Aggregates.Tasks;
 using TaskStatus = PraxisNote.Domain.ValueObjects.TaskStatus;
 
 namespace PraxisNote.Application.Features.Tasks;
 
-public sealed class GetUserTasks(ITaskRepository taskRepository)
+public sealed class GetUserTasks(ITaskRepository taskRepository, IOptions<TaskSettings> settings)
 {
+    private readonly TaskSettings _settings = settings.Value;
+
     public record Query(Guid UserId, bool IncludeArchived = false);
 
     public async Task<IReadOnlyList<TaskDto>> ExecuteAsync(Query query, CancellationToken cancellationToken = default)
     {
         var tasks = await taskRepository.GetByUserIdAsync(query.UserId, cancellationToken);
-        var archiveThreshold = DateTimeOffset.UtcNow.AddDays(-TaskConstants.ArchiveThresholdDays);
+        var archiveThreshold = DateTimeOffset.UtcNow.AddDays(-_settings.ArchiveThresholdDays);
 
         var filteredTasks = query.IncludeArchived
             ? tasks
@@ -18,7 +21,7 @@ public sealed class GetUserTasks(ITaskRepository taskRepository)
                     && t.CompletedAt.HasValue
                     && t.CompletedAt.Value < archiveThreshold)
                 .OrderByDescending(t => t.CompletedAt)
-                .Take(TaskConstants.MaxArchivedTasks)
+                .Take(_settings.MaxArchivedTasks)
             : tasks
                 .Where(t => t.Status != TaskStatus.Done
                     || !t.CompletedAt.HasValue

--- a/src/PraxisNote.Application/Features/Tasks/TaskConstants.cs
+++ b/src/PraxisNote.Application/Features/Tasks/TaskConstants.cs
@@ -1,7 +1,0 @@
-namespace PraxisNote.Application.Features.Tasks;
-
-public static class TaskConstants
-{
-    public const int ArchiveThresholdDays = 7;
-    public const int MaxArchivedTasks = 50;
-}

--- a/src/PraxisNote.Application/Features/Tasks/TaskSettings.cs
+++ b/src/PraxisNote.Application/Features/Tasks/TaskSettings.cs
@@ -1,0 +1,9 @@
+namespace PraxisNote.Application.Features.Tasks;
+
+public class TaskSettings
+{
+    public const string SectionName = "Tasks";
+
+    public int ArchiveThresholdDays { get; set; } = 2;
+    public int MaxArchivedTasks { get; set; } = 50;
+}

--- a/src/PraxisNote.Application/PraxisNote.Application.csproj
+++ b/src/PraxisNote.Application/PraxisNote.Application.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.1" />
   </ItemGroup>
 
 </Project>

--- a/src/PraxisNote.Web/Program.cs
+++ b/src/PraxisNote.Web/Program.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.FileProviders;
 using PraxisNote.Application;
+using PraxisNote.Application.Features.Tasks;
 using PraxisNote.Infrastructure;
 using PraxisNote.Infrastructure.Persistence;
 using PraxisNote.Web.Auth;
@@ -21,6 +22,9 @@ builder.Services.Configure<ForwardedHeadersOptions>(options =>
     options.KnownIPNetworks.Clear();
     options.KnownProxies.Clear();
 });
+
+// Configure Task settings
+builder.Services.Configure<TaskSettings>(builder.Configuration.GetSection(TaskSettings.SectionName));
 
 // Add Application services (use cases)
 builder.Services.AddApplication();

--- a/src/PraxisNote.Web/appsettings.json
+++ b/src/PraxisNote.Web/appsettings.json
@@ -6,6 +6,10 @@
     }
   },
   "AllowedHosts": "*",
+  "Tasks": {
+    "ArchiveThresholdDays": 2,
+    "MaxArchivedTasks": 50
+  },
   "ConnectionStrings": {
     "DefaultConnection": ""
   },

--- a/tests/PraxisNote.E2E.Tests/helpers/archive-helpers.ts
+++ b/tests/PraxisNote.E2E.Tests/helpers/archive-helpers.ts
@@ -9,20 +9,23 @@ const connectionConfig = {
   password: 'e2eTestPassword',
 };
 
+// Archive threshold must match appsettings.json Tasks:ArchiveThresholdDays
+const ARCHIVE_THRESHOLD_DAYS = 2;
+
 /**
- * Seeds a task that is considered "archived" (completed more than 7 days ago)
+ * Seeds a task that is considered "archived" (completed more than 2 days ago)
  * @param userId The user ID to associate the task with
  * @param title The task title
- * @param daysAgo How many days ago the task was completed (must be > 7 for archiving)
+ * @param daysAgo How many days ago the task was completed (must be > 2 for archiving)
  * @returns The created task ID
  */
 export async function seedArchivedTask(
   userId: string,
   title: string,
-  daysAgo: number = 10
+  daysAgo: number = 5
 ): Promise<string> {
-  if (daysAgo <= 7) {
-    throw new Error('daysAgo must be > 7 for an archived task');
+  if (daysAgo <= ARCHIVE_THRESHOLD_DAYS) {
+    throw new Error(`daysAgo must be > ${ARCHIVE_THRESHOLD_DAYS} for an archived task`);
   }
 
   const client = new Client(connectionConfig);
@@ -63,7 +66,7 @@ export async function seedArchivedTask(
 }
 
 /**
- * Seeds a recently completed task (within the last 7 days, not archived)
+ * Seeds a recently completed task (within the last 2 days, not archived)
  * @param userId The user ID to associate the task with
  * @param title The task title
  * @returns The created task ID
@@ -78,7 +81,7 @@ export async function seedRecentDoneTask(
   try {
     const taskId = randomUUID();
     const now = new Date();
-    const completedAt = new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000); // 2 days ago
+    const completedAt = new Date(now.getTime() - 1 * 24 * 60 * 60 * 1000); // 1 day ago (within threshold)
     const startedAt = new Date(completedAt.getTime() - 60 * 60 * 1000); // 1 hour before completed
     const createdAt = new Date(startedAt.getTime() - 60 * 60 * 1000); // 1 hour before started
 

--- a/tests/PraxisNote.E2E.Tests/smoke-tests/archive.spec.ts
+++ b/tests/PraxisNote.E2E.Tests/smoke-tests/archive.spec.ts
@@ -39,9 +39,9 @@ test.describe('Archive', () => {
   });
 
   test('archive count badge shows number of archived tasks', async ({ page }) => {
-    // Seed an archived task (completed > 7 days ago)
-    await seedArchivedTask(testUser.userId, 'Archived Task 1', 10);
-    await seedArchivedTask(testUser.userId, 'Archived Task 2', 14);
+    // Seed archived tasks (completed > 2 days ago per appsettings.json)
+    await seedArchivedTask(testUser.userId, 'Archived Task 1', 5);
+    await seedArchivedTask(testUser.userId, 'Archived Task 2', 7);
 
     await setupAuth(page, testUser);
     await page.goto('/tasks');
@@ -55,7 +55,7 @@ test.describe('Archive', () => {
   test('archive toggle switches Done column to Archive view', async ({ page }) => {
     // Seed both a recent done task and an archived task
     await seedRecentDoneTask(testUser.userId, 'Recent Done Task');
-    await seedArchivedTask(testUser.userId, 'Old Archived Task', 10);
+    await seedArchivedTask(testUser.userId, 'Old Archived Task', 5);
 
     await setupAuth(page, testUser);
     await page.goto('/tasks');
@@ -82,7 +82,7 @@ test.describe('Archive', () => {
 
   test('archive view can be toggled back to Done view', async ({ page }) => {
     await seedRecentDoneTask(testUser.userId, 'Recent Task');
-    await seedArchivedTask(testUser.userId, 'Archived Task', 10);
+    await seedArchivedTask(testUser.userId, 'Archived Task', 5);
 
     await setupAuth(page, testUser);
     await page.goto('/tasks');
@@ -98,7 +98,7 @@ test.describe('Archive', () => {
   });
 
   test('archived tasks can be edited', async ({ page }) => {
-    await seedArchivedTask(testUser.userId, 'Edit This Archived Task', 10);
+    await seedArchivedTask(testUser.userId, 'Edit This Archived Task', 5);
 
     await setupAuth(page, testUser);
     await page.goto('/tasks');
@@ -129,7 +129,7 @@ test.describe('Archive', () => {
 
   test('empty archive view shows appropriate message', async ({ page, request }) => {
     // Seed an archived task first so button appears
-    const archivedId = await seedArchivedTask(testUser.userId, 'Temp Archived Task', 10);
+    const archivedId = await seedArchivedTask(testUser.userId, 'Temp Archived Task', 5);
 
     await setupAuth(page, testUser);
     await page.goto('/tasks');


### PR DESCRIPTION
## Summary

- Change archive threshold from 7 days to 2 days
- Move archive settings to configuration (appsettings.json) instead of hardcoded constants
- Add TaskSettings class with configurable `ArchiveThresholdDays` and `MaxArchivedTasks`
- Inject `IOptions<TaskSettings>` into GetUserTasks and GetArchivedCount

## Changes

| File | Change |
|------|--------|
| `TaskSettings.cs` | New configuration class |
| `appsettings.json` | Add Tasks section with defaults |
| `GetUserTasks.cs` | Use injected settings |
| `GetArchivedCount.cs` | Use injected settings |
| `Program.cs` | Register TaskSettings configuration |
| `TaskConstants.cs` | Deleted (replaced by TaskSettings) |
| E2E test helpers | Updated for 2-day threshold |

## Test plan

- [x] Build succeeds
- [x] Unit tests pass (205 tests)
- [ ] E2E tests (requires Docker - will verify in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Task archiving configuration is now dynamically configurable through application settings.

* **Refactor**
  * Migrated hardcoded archive constants to configurable application settings pattern.

* **Chores**
  * Updated test data and defaults; archive threshold changed to 2 days.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->