### PR TITLE
Add linkify pipe to make URLs in comments clickable

### DIFF
--- a/src/PraxisNote.Web/ClientApp/src/app/shared/pipes/linkify.pipe.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/shared/pipes/linkify.pipe.ts
@@ -1,0 +1,116 @@
+import { Pipe, PipeTransform, inject } from '@angular/core';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+
+// URL regex that matches http://, https://, and www. URLs
+const URL_REGEX = /(?:https?:\/\/|www\.)[^\s<>"')\]]+/gi;
+
+// Maximum display length for URLs before truncation
+const MAX_URL_DISPLAY_LENGTH = 40;
+
+@Pipe({
+  name: 'linkify',
+  standalone: true,
+  pure: true,
+})
+export class LinkifyPipe implements PipeTransform {
+  private readonly sanitizer = inject(DomSanitizer);
+
+  transform(text: string | null | undefined): SafeHtml {
+    if (!text) {
+      return '';
+    }
+
+    // Find all URLs and their positions
+    const matches: { index: number; length: number; url: string }[] = [];
+    let match: RegExpExecArray | null;
+
+    // Reset regex lastIndex
+    URL_REGEX.lastIndex = 0;
+
+    while ((match = URL_REGEX.exec(text)) !== null) {
+      matches.push({
+        index: match.index,
+        length: match[0].length,
+        url: match[0],
+      });
+    }
+
+    // If no URLs found, escape and return the text
+    if (matches.length === 0) {
+      return this.escapeHtml(text);
+    }
+
+    // Build the result by processing segments
+    let result = '';
+    let lastIndex = 0;
+
+    for (const { index, length, url } of matches) {
+      // Add escaped text before this URL
+      if (index > lastIndex) {
+        result += this.escapeHtml(text.substring(lastIndex, index));
+      }
+
+      // Add the link
+      result += this.createLink(url);
+      lastIndex = index + length;
+    }
+
+    // Add any remaining text after the last URL
+    if (lastIndex < text.length) {
+      result += this.escapeHtml(text.substring(lastIndex));
+    }
+
+    // Mark as safe HTML (we've escaped user content and only added our own markup)
+    return this.sanitizer.bypassSecurityTrustHtml(result);
+  }
+
+  private createLink(url: string): string {
+    // Ensure URL has protocol for href
+    const href = url.startsWith('www.') ? `https://${url}` : url;
+
+    // Create truncated display text
+    const displayText = this.truncateUrl(url);
+
+    // Escape any HTML in the URL itself (for the href and title attributes)
+    const safeHref = this.escapeAttr(href);
+    const safeTitle = this.escapeAttr(url);
+    const safeDisplay = this.escapeHtml(displayText);
+
+    return `<a href="${safeHref}" target="_blank" rel="noopener noreferrer" title="${safeTitle}" class="text-primary hover:underline break-all">${safeDisplay}</a>`;
+  }
+
+  private truncateUrl(url: string): string {
+    if (url.length <= MAX_URL_DISPLAY_LENGTH) {
+      return url;
+    }
+
+    // Remove protocol for display
+    let display = url.replace(/^https?:\/\//, '');
+
+    if (display.length <= MAX_URL_DISPLAY_LENGTH) {
+      return display;
+    }
+
+    // Truncate with ellipsis
+    return display.substring(0, MAX_URL_DISPLAY_LENGTH - 3) + '...';
+  }
+
+  private escapeHtml(text: string): string {
+    return text
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#039;')
+      .replace(/\n/g, '<br>');
+  }
+
+  private escapeAttr(text: string): string {
+    return text
+      .replace(/&/g, '&amp;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#039;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+  }
+}

--- a/src/PraxisNote.Web/ClientApp/src/app/tasks/task-card.component.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/tasks/task-card.component.ts
@@ -3,6 +3,7 @@ import { NgClass } from '@angular/common';
 import { Task, Comment } from './task.model';
 import { AutoResizeDirective } from '../shared/directives/auto-resize.directive';
 import { StatusColorPipe } from '../shared/pipes/status-color.pipe';
+import { LinkifyPipe } from '../shared/pipes/linkify.pipe';
 import { DeleteConfirmationService } from '../shared/services/delete-confirmation.service';
 import { DueDateBadgeComponent } from './due-date-badge.component';
 
@@ -10,7 +11,7 @@ import { DueDateBadgeComponent } from './due-date-badge.component';
   selector: 'app-task-card',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [NgClass, AutoResizeDirective, StatusColorPipe, DueDateBadgeComponent],
+  imports: [NgClass, AutoResizeDirective, StatusColorPipe, LinkifyPipe, DueDateBadgeComponent],
   template: `
     <div
       class="bg-surface rounded-md py-2 px-3 border transition-colors group"
@@ -146,12 +147,12 @@ import { DueDateBadgeComponent } from './due-date-badge.component';
                   class="group/comment flex items-start gap-1.5 cursor-pointer text-xs"
                   role="button"
                   tabindex="0"
-                  (click)="startCommentEdit(comment); $event.stopPropagation()"
+                  (click)="onCommentClick($event, comment)"
                   (keydown.enter)="startCommentEdit(comment); $event.preventDefault(); $event.stopPropagation()"
                   (keydown.space)="startCommentEdit(comment); $event.preventDefault(); $event.stopPropagation()"
                 >
                   <i class="pi pi-comment text-foreground-muted/40 shrink-0 mt-0.5"></i>
-                  <span class="text-foreground-muted flex-1 min-w-0 whitespace-pre-wrap">{{ comment.content }}</span>
+                  <span class="text-foreground-muted flex-1 min-w-0 break-words" [innerHTML]="comment.content | linkify"></span>
                   @if (confirmingCommentDeleteId() === comment.id) {
                     <!-- Delete confirmation mode -->
                     <button
@@ -304,6 +305,18 @@ export class TaskCardComponent {
     const dateStr = comment.updatedAt !== comment.createdAt ? comment.updatedAt : comment.createdAt;
     const prefix = comment.updatedAt !== comment.createdAt ? 'edited ' : '';
     return prefix + this.formatTime(dateStr, 'completed');
+  }
+
+  onCommentClick(event: MouseEvent, comment: Comment): void {
+    event.stopPropagation();
+
+    // Check if the click was on a link - don't trigger edit mode
+    const target = event.target as HTMLElement;
+    if (target.tagName === 'A' || target.closest('a')) {
+      return;
+    }
+
+    this.startCommentEdit(comment);
   }
 
   startCommentEdit(comment: Comment): void {


### PR DESCRIPTION
## Summary
- Created `LinkifyPipe` that detects URLs in comment text and transforms them to clickable links
- URLs are truncated visually (max 40 chars) with ellipsis to prevent overflow
- Full URL shown in tooltip on hover via `title` attribute
- Links open in new tab with `target="_blank"` and `rel="noopener noreferrer"` for security
- Clicking a link does NOT trigger comment edit mode

## Implementation Details
- Uses regex to detect `http://`, `https://`, and `www.` URLs
- Properly escapes HTML to prevent XSS attacks
- Uses Angular's `DomSanitizer` to safely render HTML
- Added `break-words` class to handle long URLs without horizontal overflow

## Test plan
- [x] Unit tests pass (205 tests)
- [x] E2E tests pass (21 tests)
- [ ] Add a comment with a URL like `https://github.com/user/repo/issues/123`
- [ ] Verify URL is clickable and opens in new tab
- [ ] Verify long URLs are truncated with ellipsis
- [ ] Verify hovering shows full URL in tooltip
- [ ] Verify clicking link does NOT trigger comment edit mode
- [ ] Verify no horizontal overflow with long URLs

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Task comments now automatically detect and convert URLs (http, https, www) into clickable links. Links open in a new tab with security safeguards. Clicking links doesn't trigger edit mode, allowing users to edit comment text as usual.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->