### PR TITLE
Fix comment input retaining height after submission

### DIFF
--- a/src/PraxisNote.Web/ClientApp/src/app/tasks/task-card.component.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/tasks/task-card.component.ts
@@ -412,6 +412,11 @@ export class TaskCardComponent {
     if (content) {
       this.onAddComment.emit(content);
       this.newCommentText.set('');
+      // Reset textarea height after clearing content
+      const textarea = this.newCommentInput()?.nativeElement;
+      if (textarea) {
+        textarea.style.height = 'auto';
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Reset textarea height to `auto` after submitting a multiline comment so it returns to single-line height

Fixes #92

## Test plan
- [ ] Create a multiline comment (press Enter to add lines)
- [ ] Submit the comment
- [ ] Verify the input area resets to default single-line height

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed textarea height behavior after submitting a comment—the textarea now properly resets to its default size instead of remaining expanded.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->