### PR TITLE
Add +35 days shortcut to due date picker

### DIFF
--- a/src/PraxisNote.Web/ClientApp/src/app/tasks/date-picker-popover.component.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/tasks/date-picker-popover.component.ts
@@ -51,6 +51,14 @@ import { DatePicker } from 'primeng/datepicker';
         >
           +7
         </button>
+        <button
+          type="button"
+          (click)="selectQuickOption('plus35'); $event.stopPropagation()"
+          class="px-2 py-0.5 text-xs font-medium rounded-full transition-colors"
+          [class]="isSelected('plus35') ? 'bg-slate-200 text-slate-700' : 'bg-slate-100 text-slate-600 hover:bg-slate-200'"
+        >
+          +35
+        </button>
         @if (currentDate()) {
           <button
             type="button"
@@ -112,13 +120,13 @@ export class DatePickerPopoverComponent {
     }
   }
 
-  selectQuickOption(option: 'today' | 'tomorrow' | 'nextWeek'): void {
+  selectQuickOption(option: 'today' | 'tomorrow' | 'nextWeek' | 'plus35'): void {
     const date = this.getQuickOptionDate(option);
     this.selectedDate.set(date);
     this.onSelect.emit(this.formatDate(date));
   }
 
-  private getQuickOptionDate(option: 'today' | 'tomorrow' | 'nextWeek'): Date {
+  private getQuickOptionDate(option: 'today' | 'tomorrow' | 'nextWeek' | 'plus35'): Date {
     const today = new Date();
     today.setHours(0, 0, 0, 0);
 
@@ -129,10 +137,12 @@ export class DatePickerPopoverComponent {
         return new Date(today.getTime() + 86400000);
       case 'nextWeek':
         return new Date(today.getTime() + 7 * 86400000);
+      case 'plus35':
+        return new Date(today.getTime() + 35 * 86400000);
     }
   }
 
-  isSelected(option: 'today' | 'tomorrow' | 'nextWeek'): boolean {
+  isSelected(option: 'today' | 'tomorrow' | 'nextWeek' | 'plus35'): boolean {
     const current = this.currentDate();
     if (!current) return false;
 


### PR DESCRIPTION
## Summary
- Add quick-select option to set a task's due date to 35 days from today
- Complements existing shortcuts (Today, +1, +7)

Fixes #93

## Test plan
- [ ] Open a task's due date picker
- [ ] Verify the "+35" button appears after "+7"
- [ ] Click "+35" and verify the date is set to 35 days from today
- [ ] Verify the button highlights when that date is already selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new quick date option to the date picker that allows users to quickly set task dates 35 days in the future for improved scheduling efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->