### PR TITLE
Fix linkify pipe to strip trailing punctuation from URLs

### DIFF
--- a/src/PraxisNote.Web/ClientApp/src/app/shared/pipes/linkify.pipe.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/shared/pipes/linkify.pipe.ts
@@ -4,6 +4,10 @@ import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 // URL regex that matches http://, https://, and www. URLs
 const URL_REGEX = /(?:https?:\/\/|www\.)[^\s<>"')\]]+/gi;
 
+// Trailing punctuation that should be stripped from URLs
+// These are common sentence-ending punctuation that get captured but aren't part of the URL
+const TRAILING_PUNCTUATION = /[.,!?;:]+$/;
+
 // Maximum display length for URLs before truncation
 const MAX_URL_DISPLAY_LENGTH = 40;
 
@@ -28,10 +32,13 @@ export class LinkifyPipe implements PipeTransform {
     URL_REGEX.lastIndex = 0;
 
     while ((match = URL_REGEX.exec(text)) !== null) {
+      // Strip trailing punctuation from URLs (e.g., "Check https://example.com." -> period is not part of URL)
+      const rawUrl = match[0];
+      const url = rawUrl.replace(TRAILING_PUNCTUATION, '');
       matches.push({
         index: match.index,
-        length: match[0].length,
-        url: match[0],
+        length: url.length, // Use cleaned URL length so punctuation becomes regular text
+        url,
       });
     }
 


### PR DESCRIPTION
## Summary
- Fix URLs in comments including trailing sentence punctuation (`.`, `,`, `!`, `?`, `;`, `:`) which created broken links
- Now "Check out https://example.com." correctly linkifies just the URL, leaving the period as text

## Test plan
- [ ] Add a comment like "Check https://example.com." - verify the period is not part of the link
- [ ] Add a comment like "Visit https://example.com, and https://other.com!" - verify both links work without trailing punctuation
- [ ] Verify existing URL-only comments still work

Fixes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved URL link detection to properly handle trailing punctuation, ensuring punctuation at the end of links (such as periods or commas) is treated as regular text outside the link.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->