### PR TITLE
Add drag handle to prevent accidental drags during text selection

### DIFF
--- a/src/PraxisNote.Web/ClientApp/src/app/tasks/column.component.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/tasks/column.component.ts
@@ -170,13 +170,20 @@ type SortMode = 'manual' | 'dueDate';
         }
         @for (task of sortedTasks(); track task.id) {
           <div cdkDrag [cdkDragData]="task" class="group/drag relative touch-manipulation">
-            <!-- Drag handle - visible on hover -->
+            <!-- Drag handle - visible on hover (2x3 dot grip pattern) -->
             <div
               cdkDragHandle
-              class="absolute -left-1 top-1/2 -translate-y-1/2 w-4 h-8 flex items-center justify-center cursor-grab active:cursor-grabbing opacity-0 group-hover/drag:opacity-100 transition-opacity z-10"
+              class="absolute -left-2 top-1/2 -translate-y-1/2 w-5 h-8 flex items-center justify-center cursor-grab active:cursor-grabbing opacity-0 group-hover/drag:opacity-100 transition-opacity z-10"
               aria-label="Drag to reorder"
             >
-              <i class="pi pi-ellipsis-v text-xs text-foreground-muted/50 hover:text-foreground-muted"></i>
+              <div class="grid grid-cols-2 gap-0.5">
+                <span class="w-1 h-1 rounded-full bg-foreground-muted/40"></span>
+                <span class="w-1 h-1 rounded-full bg-foreground-muted/40"></span>
+                <span class="w-1 h-1 rounded-full bg-foreground-muted/40"></span>
+                <span class="w-1 h-1 rounded-full bg-foreground-muted/40"></span>
+                <span class="w-1 h-1 rounded-full bg-foreground-muted/40"></span>
+                <span class="w-1 h-1 rounded-full bg-foreground-muted/40"></span>
+              </div>
             </div>
             <app-task-card
               [task]="task"


### PR DESCRIPTION
## Summary
- Added a grip icon drag handle that appears on hover to the left of each task card
- Users can only drag cards from this handle, not the entire card
- Allows normal text selection and clicking on the rest of the card

## Test plan
- [ ] Hover over a task card - verify grip icon appears on the left
- [ ] Drag from the grip icon - verify card drags normally
- [ ] Click on task title - verify edit mode activates (not drag)
- [ ] Click on links in comments - verify links work
- [ ] Try to drag from the card body - verify dragging doesn't start

Fixes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated drag handle to task columns for improved reordering.
  * Drag handle appears on hover with an accessible label and visual indicator for better usability.
  * Task items retain overall drag area while providing a focused handle for more precise dragging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->