### PR TITLE
Fix notifications marked as seen on panel close, not open

### DIFF
--- a/src/PraxisNote.Web/ClientApp/src/app/notifications/notification-panel.component.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/notifications/notification-panel.component.ts
@@ -137,17 +137,17 @@ export class NotificationPanelComponent {
   protected readonly activeTab = signal<'new' | 'history'>('new');
 
   constructor() {
-    // Load notifications and auto-mark as seen when panel opens
+    // Load notifications when panel opens
     effect(() => {
       if (this.visible()) {
         this.notificationService.loadNotifications();
-        // Auto-mark as seen after a brief delay
-        setTimeout(() => this.notificationService.markAllAsSeen(), 1000);
       }
     });
   }
 
   protected close(): void {
+    // Mark notifications as seen when closing the panel
+    this.notificationService.markAllAsSeen();
     this.visibleChange.emit(false);
   }
 


### PR DESCRIPTION
## Summary
- Notifications are now marked as seen when the panel **closes** instead of when it opens
- Removes the incorrect 1-second auto-mark behavior

Fixes #119

## Test plan
- [ ] Open notification panel with unread notifications
- [ ] Verify badge count remains while panel is open
- [ ] Close the panel
- [ ] Verify badge count clears after closing
- [ ] Reopen panel and verify notifications moved to History tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed notification panel loading behavior to eliminate unnecessary delays; notifications now appear instantly when you open the panel for faster access.
  * Improved notification state handling: all notifications are now explicitly marked as seen when you close the panel, ensuring consistent and accurate notification tracking across your sessions and interactions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->