### PR TITLE
Add feature status indicators to home page (#123)

### DIFF
--- a/src/PraxisNote.Web/ClientApp/src/app/home/home.page.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/home/home.page.ts
@@ -78,7 +78,7 @@ import { AuthService } from '../auth';
       <!-- Empty state card -->
       <div class="bg-surface border border-border rounded-2xl p-8 lg:p-12 text-center">
         <div class="w-16 h-16 rounded-2xl bg-gradient-to-br from-green-100 to-emerald-100 flex items-center justify-center mx-auto mb-5">
-          <i class="pi pi-check-square text-3xl text-done-foreground"></i>
+          <i class="pi pi-check-square text-3xl text-done-foreground" aria-hidden="true"></i>
         </div>
         <h2 class="text-xl font-semibold text-foreground mb-2">Your workspace is ready</h2>
         <p class="text-foreground-secondary mb-8 max-w-md mx-auto">


### PR DESCRIPTION
## Summary
- Add visual status badges to home page quick action buttons
- Live features (Tasks) show green "Live" badge with check-circle icon
- Coming Soon features (New Note, Search) show amber "Soon" badge with clock icon
- Badges include both icon and text for accessibility (not color-only)
- Dark mode support with appropriate color variants
- Coming Soon buttons have reduced opacity and cursor-not-allowed

Closes #123

## Test plan
- [ ] Verify "Tasks" button shows green "Live" badge
- [ ] Verify "New Note" and "Search" buttons show amber "Soon" badges
- [ ] Click "Tasks" - should navigate to /tasks
- [ ] Click "New Note" or "Search" - nothing happens (no navigation)
- [ ] Check badges display correctly on mobile viewport
- [ ] Toggle dark mode and verify badge colors adapt

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tasks is now live and directly accessible from the home screen with a "Live" card; primary actions navigate to Tasks.

* **Updates**
  * "New Note" and "Search" are marked "Coming Soon" with a disabled appearance and time badges.
  * Empty-state visuals, color, and copy now promote tasks/kanban workflows; action changed to "Create your first task" and links to Tasks.

* **Accessibility**
  * Action buttons include improved disabled semantics and clearer labels for assistive tech.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->