### PR TITLE
Fix deploy badge to render locally (#108)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PraxisNote
 
-[![Deploy](https://github.com/garethbaumgart/praxis-note/actions/workflows/deploy-cloud-run.yml/badge.svg?branch=main)](https://github.com/garethbaumgart/praxis-note/actions/workflows/deploy-cloud-run.yml)
+[![Deploy](https://img.shields.io/github/actions/workflow/status/garethbaumgart/praxis-note/deploy-cloud-run.yml?branch=main&label=Deploy)](https://github.com/garethbaumgart/praxis-note/actions/workflows/deploy-cloud-run.yml)
 ![Unit Tests](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/garethbaumgart/093c03c9b23736d0600e9eeb2e772063/raw/unit-tests.json)
 ![E2E Tests](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/garethbaumgart/093c03c9b23736d0600e9eeb2e772063/raw/e2e-tests.json)
 ![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/garethbaumgart/093c03c9b23736d0600e9eeb2e772063/raw/coverage.json)


### PR DESCRIPTION
## Summary
- Switch Deploy badge from GitHub's native badge URL to shields.io
- GitHub's native badges require authentication outside of GitHub
- shields.io badges render consistently everywhere

Closes #108

## Test plan
- [ ] View README on GitHub - badge renders
- [ ] View README locally (e.g., VS Code preview) - badge renders
- [ ] Badge still links to the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)