### PR TITLE
Reduce mobile drag delay from 200ms to 150ms

### DIFF
--- a/src/PraxisNote.Web/ClientApp/src/app/tasks/column.component.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/tasks/column.component.ts
@@ -188,7 +188,7 @@ type SortMode = 'manual' | 'dueDate' | 'priority';
           }
         } @else {
           @for (task of sortedTasks(); track task.id) {
-            <div cdkDrag [cdkDragData]="task" [cdkDragStartDelay]="{ touch: 200, mouse: 0 }" class="cursor-grab active:cursor-grabbing touch-manipulation">
+            <div cdkDrag [cdkDragData]="task" [cdkDragStartDelay]="{ touch: 150, mouse: 0 }" class="cursor-grab active:cursor-grabbing touch-manipulation">
               <app-task-card
                 [task]="task"
                 (onEdit)="onEditTask.emit({ id: task.id, title: $event })"


### PR DESCRIPTION
## Summary

Reduces touch drag start delay from 200ms to 150ms for snappier feel on mobile.

## Changes

- `column.component.ts`: `cdkDragStartDelay` touch value 200 → 150

## Test plan

- [ ] Drag tasks on mobile - feels responsive
- [ ] Scroll on mobile - no accidental drags
- [ ] E2E tests pass (22 tests)

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Adjust touch drag start delay on task cards from 200ms to 150ms for a snappier mobile drag experience.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Improved touch interaction responsiveness for task items. The drag response time on task elements has been optimized for touch devices, resulting in faster initiation of drag operations. Users will now experience more immediate visual feedback and smoother task reordering interactions, enhancing overall responsiveness when managing tasks via touch input.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->