### PR TITLE
Close expanded task content when clicking outside or pressing Escape (#158)

### DIFF
--- a/src/PraxisNote.Web/ClientApp/src/app/tasks/task-card.component.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/tasks/task-card.component.ts
@@ -283,7 +283,7 @@ export class TaskCardComponent {
   private readonly injector = inject(Injector);
   private readonly destroyRef = inject(DestroyRef);
   private readonly deleteConfirmation = inject(DeleteConfirmationService);
-  private readonly elementRef = inject(ElementRef);
+  private readonly elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
 
   // Flag to prevent click-outside from firing during initial render
   private initialized = false;
@@ -456,7 +456,10 @@ export class TaskCardComponent {
   onDocumentClick(event: Event): void {
     if (!this.initialized || !this.selectedTab()) return;
 
-    const target = event.target as HTMLElement;
+    const target = event.target;
+    // Guard for non-Node targets (e.g., SVG elements in some browsers)
+    if (!(target instanceof Node)) return;
+
     if (!this.elementRef.nativeElement.contains(target)) {
       this.closeExpanded();
     }


### PR DESCRIPTION
## Summary
- Add click-outside detection to task cards so expanded content closes when clicking outside
- Add Escape key handler to close expanded tabs
- When clicking one task, other expanded tasks automatically close
- Follows existing pattern from date-picker-popover component

Closes #158

## Test plan
- [x] Run `dotnet test` - all 240 tests pass
- [x] Run E2E tests - all 22 tests pass
- [ ] Manual test: Click task comment tab -> click outside -> tab closes
- [ ] Manual test: Expand task -> click another task -> first task closes
- [ ] Manual test: Expand task -> press Escape -> tab closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Improve task card interactions so expanded content closes automatically in more scenarios.

New Features:
- Allow task card expanded content to close when clicking outside the card.
- Allow task card expanded content to close when pressing the Escape key.

Enhancements:
- Ensure only one task card remains expanded by closing the current card when its expanded state is cleared via the new close behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
* Expanded task cards now close automatically when clicking outside the card area.
* Pressing the Escape key now closes expanded task cards and hides any open panels.
* Improved keyboard navigation and interaction efficiency for task management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->