### PR TITLE
Show search result count when filtering tasks (#148)

### DIFF
--- a/src/PraxisNote.Web/ClientApp/src/app/tasks/tasks.page.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/tasks/tasks.page.ts
@@ -28,11 +28,15 @@ import { ToastService } from '../shared/services/toast.service';
           [value]="searchQuery()"
           (input)="searchQuery.set(asInput($event).value)"
           (keydown.escape)="clearSearch()"
-          class="w-full h-9 pl-9 pr-16 text-sm text-foreground-secondary placeholder-foreground-secondary bg-surface-muted hover:bg-surface-muted/80 focus:bg-surface-muted/80 rounded-lg focus:outline-none transition-colors duration-150"
+          class="w-full h-9 pl-9 pr-28 text-sm text-foreground-secondary placeholder-foreground-secondary bg-surface-muted hover:bg-surface-muted/80 focus:bg-surface-muted/80 rounded-lg focus:outline-none transition-colors duration-150"
           aria-label="Search tasks"
         >
         @if (searchQuery().trim()) {
-          <span class="absolute right-9 top-1/2 -translate-y-1/2 text-xs text-foreground-muted">
+          <span
+            class="absolute right-12 top-1/2 -translate-y-1/2 text-xs text-foreground-muted"
+            role="status"
+            aria-live="polite"
+          >
             {{ getSearchResultLabel(searchResultCount()) }}
           </span>
         }


### PR DESCRIPTION
## Summary
- Adds result count display next to search input when filtering tasks
- Shows "No results" when search matches nothing
- Shows "1 result" or "N results" for matches
- Updates in real-time as user types

Closes #148

## Test plan
- [ ] Type in search box and verify result count appears
- [ ] Verify "No results" shows when no tasks match
- [ ] Verify count uses correct singular/plural ("1 result" vs "2 results")
- [ ] Verify count updates as you type
- [ ] Clear search and verify count disappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Display the number of matching tasks next to the search field when filtering, including a "No results" message when there are no matches.

New Features:
- Show a dynamic search result count beside the task search input while a query is active.

Enhancements:
- Update the search input UI to reposition the clear button and replace the keyboard shortcut hint with the result count when searching.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Live search results counter now displays a real-time count of matching tasks as you type in the search field
* Enhanced search input styling with improved spacing and padding for better visual presentation
* Result count displays in user-friendly text format, including "No results", "1 result", and "n results" variations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->