### PR TITLE
fix: Add retry logic for database migrations during Cloud Run cold start

### DIFF
--- a/src/PraxisNote.Web/Program.cs
+++ b/src/PraxisNote.Web/Program.cs
@@ -138,11 +138,34 @@ var app = builder.Build();
 // Use forwarded headers (must be first - for Cloud Run / load balancers)
 app.UseForwardedHeaders();
 
-// Apply database migrations on startup (safe for single-instance Cloud Run)
-using (var scope = app.Services.CreateScope())
+// Apply database migrations on startup with retry logic for Cloud Run cold starts
+// Cloud Run may start the container before the database connection is fully ready
+var maxRetries = 5;
+var retryDelaySeconds = 3;
+
+for (var attempt = 1; attempt <= maxRetries; attempt++)
 {
-    var db = scope.ServiceProvider.GetRequiredService<PraxisNoteDbContext>();
-    db.Database.Migrate();
+    try
+    {
+        using var scope = app.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<PraxisNoteDbContext>();
+        db.Database.Migrate();
+        app.Logger.LogInformation("Database migrations applied successfully");
+        break;
+    }
+    catch (Exception ex) when (attempt < maxRetries)
+    {
+        app.Logger.LogWarning(
+            ex,
+            "Database migration attempt {Attempt}/{MaxRetries} failed. Retrying in {Delay}s...",
+            attempt, maxRetries, retryDelaySeconds);
+        Thread.Sleep(TimeSpan.FromSeconds(retryDelaySeconds));
+    }
+    catch (Exception ex)
+    {
+        app.Logger.LogError(ex, "Database migration failed after {MaxRetries} attempts", maxRetries);
+        throw; // Re-throw on final attempt to fail startup
+    }
 }
 
 // HTTPS redirection (production security)


### PR DESCRIPTION
## Summary
- Fix Cloud Run deployment failures that have been occurring since Jan 22
- The container was crashing on startup because database migrations would throw an unhandled exception if the database connection wasn't immediately available during cold start
- Added retry logic (5 attempts with 3s delay) to handle transient database connectivity issues during container startup

## Root Cause
The `db.Database.Migrate()` call in `Program.cs` would throw an unhandled exception if the database wasn't immediately reachable. This caused the container to crash before the web server could start listening on port 8080, triggering Cloud Run's "container failed to start" error.

## Solution
Wrapped the migration call in a retry loop that:
- Attempts up to 5 times with 3-second delays between attempts
- Logs warnings for transient failures so they're visible in Cloud Run logs
- Still fails fast on the final attempt if the database is truly unavailable

## Test plan
- [x] All 265 unit tests pass
- [x] All 25 E2E tests pass
- [ ] Deploy to Cloud Run and verify container starts successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Prevent Cloud Run containers from crashing on startup when the database is temporarily unavailable by retrying migrations before failing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced application startup resilience with automatic retry mechanism for database initialization, providing better tolerance for deployment and environment readiness issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->