### PR TITLE
Fix note save 404, editor delete, and dashboard refresh (#265)

### DIFF
--- a/src/PraxisNote.Web/ClientApp/src/app/notes/note-editor.page.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/notes/note-editor.page.ts
@@ -734,18 +734,27 @@ export class NoteEditorPage implements OnInit, OnDestroy {
     if (this.isNewNote()) {
       // Create new note - use callback to get the real server ID
       this.isNewNote.set(false);
-      this.noteService.createNote(content, (realId) => {
-        if (this.isDestroyed) return;
-        this.noteId = realId;
-        // Find the note in the service's list to update local state
-        const n = this.noteService.notes().find(note => note.id === realId);
-        if (n) {
-          this.note.set(n);
-        }
-        // Update URL without navigation
-        this.router.navigate(['/notes', realId], { replaceUrl: true });
-        this.lastSaved.set(true);
-      });
+      this.noteService.createNote(
+        content,
+        (realId) => {
+          if (this.isDestroyed) return;
+          this.noteId = realId;
+          // Find the note in the service's list to update local state
+          const n = this.noteService.notes().find(note => note.id === realId);
+          if (n) {
+            this.note.set(n);
+          }
+          // Update URL without navigation
+          this.router.navigate(['/notes', realId], { replaceUrl: true });
+          this.lastSaved.set(true);
+        },
+        () => {
+          // Creation failed - reset so next autosave retries
+          if (!this.isDestroyed) {
+            this.isNewNote.set(true);
+          }
+        },
+      );
     } else if (this.noteId) {
       // Update existing note
       this.isSaving.set(true);

--- a/src/PraxisNote.Web/ClientApp/src/app/notes/note.service.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/notes/note.service.ts
@@ -82,7 +82,7 @@ export class NoteService {
     });
   }
 
-  createNote(content?: string, onCreated?: (id: string) => void): void {
+  createNote(content?: string, onCreated?: (id: string) => void, onError?: () => void): void {
     const tempId = crypto.randomUUID();
     const now = new Date().toISOString();
     const newNote: Note = {
@@ -109,6 +109,7 @@ export class NoteService {
         this.toast.error('Failed to create note');
         // Remove the optimistically added note
         this._notes.update(notes => notes.filter(n => n.id !== tempId));
+        onError?.();
       },
     });
   }


### PR DESCRIPTION
## Summary
- **New note 404 on autosave**: Replaced fragile content-matching poll (`watchForNewNote`) with an `onCreated` callback on `createNote()` that provides the real server ID directly from the POST response. This prevents autosave from using a temp UUID that the server doesn't recognize.
- **Delete not working in editor**: Changed `deleteNote()` to use `noteId` (always the real server ID) instead of `note().id` which could be stale after the temp-to-real ID swap.
- **Dashboard not refreshing after delete**: `loadNotes()` now filters out notes with pending deletions so the API response doesn't restore notes the user just deleted (during the 5-second undo window).

Closes #265

## Test plan
- [x] 378 unit tests pass
- [x] 25 E2E tests pass
- [ ] Create a new note, use the hyperlink action, close it, and verify autosave succeeds without 404
- [ ] Verify delete works in the note editor for both new and existing notes
- [ ] Delete a note from the editor, navigate back to dashboard, verify it's gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix note creation, deletion, and dashboard refresh behavior around optimistic updates and undoable deletes.

Bug Fixes:
- Ensure new notes use the real server ID from the create response to avoid autosave 404s.
- Fix note deletion in the editor by consistently using the canonical noteId instead of potentially stale local state.
- Prevent recently deleted notes from reappearing on the dashboard by excluding notes with pending deletions when loading from the API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved auto-save stability when creating new notes by streamlining server data synchronization
  * Enhanced note deletion operations to correctly reference server identifiers
  * Fixed filtering to properly exclude notes pending deletion from the active list

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->