### PR TITLE
Fix meetings ordering, editor default heading, and hyperlink action

### DIFF
--- a/src/PraxisNote.Web/ClientApp/src/app/meetings/meeting.service.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/meetings/meeting.service.ts
@@ -472,6 +472,15 @@ export class MeetingService {
       groups.get(dateKey)!.push(meeting);
     }
 
+    // Sort meetings within each group by time descending (newest first)
+    for (const meetings of groups.values()) {
+      meetings.sort((a, b) => {
+        const dateA = new Date(a.meetingDate ?? a.createdAt).getTime();
+        const dateB = new Date(b.meetingDate ?? b.createdAt).getTime();
+        return dateB - dateA;
+      });
+    }
+
     // Sort groups by date descending
     const sortedEntries = Array.from(groups.entries()).sort(
       (a, b) => new Date(b[0]).getTime() - new Date(a[0]).getTime()

--- a/src/PraxisNote.Web/ClientApp/src/app/notes/tiptap-editor.component.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/notes/tiptap-editor.component.ts
@@ -1066,7 +1066,7 @@ export class TiptapEditorComponent implements OnInit, OnDestroy, AfterViewInit {
       }
     } else if (isNewNote) {
       this.editor.commands.clearContent();
-      this.editor.commands.setHeading({ level: 2 });
+      this.editor.commands.setHeading({ level: 1 });
     } else {
       this.editor.commands.clearContent();
     }
@@ -1133,8 +1133,11 @@ export class TiptapEditorComponent implements OnInit, OnDestroy, AfterViewInit {
       return;
     }
 
+    // Save selection before window.prompt() steals focus
     const { from, to } = this.editor.state.selection;
-    if (from === to) {
+    const hasSelection = from !== to;
+
+    if (!hasSelection) {
       const rawUrl = window.prompt('Enter the URL:');
       if (!rawUrl) return;
 
@@ -1150,6 +1153,7 @@ export class TiptapEditorComponent implements OnInit, OnDestroy, AfterViewInit {
       this.editor
         .chain()
         .focus()
+        .setTextSelection(from)
         .insertContent({
           type: 'text',
           marks: [{ type: 'link', attrs: { href: url } }],
@@ -1166,7 +1170,12 @@ export class TiptapEditorComponent implements OnInit, OnDestroy, AfterViewInit {
         return;
       }
 
-      this.editor.chain().focus().setLink({ href: url }).run();
+      this.editor
+        .chain()
+        .focus()
+        .setTextSelection({ from, to })
+        .setLink({ href: url })
+        .run();
     }
   }
 


### PR DESCRIPTION
## Summary
- **Meetings ordered by date and time (#271):** Sort meetings within each day group by time descending so newest meetings appear first within a given date.
- **Editor defaults to heading 1 (#270):** New notes now start with Heading 1 instead of Heading 2.
- **Hyperlink editor action fixed (#269):** Save and restore editor selection around `window.prompt()` calls so link insertion works reliably — the prompt was stealing focus/selection from the editor.

Closes #269, closes #270, closes #271

## Test plan
- [x] Unit tests pass (423 tests)
- [x] E2E tests pass (25 tests)
- [x] Angular build succeeds
- [ ] Verify meetings list shows correct time ordering within a day group
- [ ] Verify new notes start with Heading 1
- [ ] Verify link button works: insert link with no selection, insert link with text selected, remove existing link

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Adjust note editor defaults and hyperlink behavior and correct meetings list ordering.

Bug Fixes:
- Preserve and restore editor text selection when inserting or updating hyperlinks so link actions work correctly with and without a selection.
- Ensure meetings within each date group are ordered by meeting time in descending order so the newest meetings appear first.

Enhancements:
- Change new note documents to start with a Heading 1 block instead of Heading 2 by default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed meeting sorting to display the newest meetings first within each date group.
  * Improved text selection preservation when inserting links in notes.
  * Adjusted default heading level for new notes to provide better document structure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->