### PR TITLE
Add Deepgram API key secret to Cloud Run deploy

### DIFF
--- a/.github/workflows/deploy-cloud-run.yml
+++ b/.github/workflows/deploy-cloud-run.yml
@@ -79,6 +79,7 @@ jobs:
             Authentication__Google__ClientId=GOOGLE_CLIENT_ID:latest
             Authentication__Google__ClientSecret=GOOGLE_CLIENT_SECRET:latest
             MeetingAnalysis__ApiKey=ANTHROPIC_API_KEY:latest
+            Deepgram__ApiKey=DEEPGRAM_API_KEY:latest
 
       - name: Show deployment URL
         run: |


### PR DESCRIPTION
## Summary
- Add `Deepgram__ApiKey=DEEPGRAM_API_KEY:latest` secret mapping to Cloud Run deploy workflow
- Follows the same convention as the existing `MeetingAnalysis__ApiKey=ANTHROPIC_API_KEY:latest`

## Prerequisites
- Create `DEEPGRAM_API_KEY` secret in GCP Secret Manager
- Grant Cloud Run service account access to the secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)