### PR TITLE
Fix insights page radar chart clipping and Johari Window sizing

### DIFF
--- a/src/PraxisNote.Web/ClientApp/src/app/insights/communication-profile.component.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/insights/communication-profile.component.ts
@@ -23,7 +23,7 @@ import { ArchetypeScore } from './insights.model';
               <p-skeleton width="50%" height="14px" styleClass="mb-4" />
               <p-skeleton width="100%" height="48px" />
             </div>
-            <p-skeleton width="300px" height="240px" />
+            <p-skeleton width="100%" height="240px" style="max-width: 300px" />
           </div>
         </div>
       } @else if (profileService.error()) {
@@ -88,8 +88,8 @@ import { ArchetypeScore } from './insights.model';
             </div>
 
             <!-- Right: Radar chart -->
-            <div class="flex-shrink-0 flex items-center justify-center">
-              <svg viewBox="0 0 340 270" width="300" height="240" role="img" [attr.aria-label]="radarAriaLabel()">
+            <div class="flex-shrink-0 flex items-center justify-center w-full max-w-[300px]">
+              <svg viewBox="0 0 340 270" class="w-full h-auto" role="img" [attr.aria-label]="radarAriaLabel()">
                 <!-- Radar grid (3 levels) -->
                 <g transform="translate(170, 130)">
                   <!-- Outer hexagon -->

--- a/src/PraxisNote.Web/ClientApp/src/app/insights/johari-window.component.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/insights/johari-window.component.ts
@@ -217,6 +217,9 @@ import { InsightsService } from './insights.service';
   `,
 })
 export class JohariWindowComponent {
+  /** Minimum fr value for grid axes — prevents tiny quadrants from becoming unreadable */
+  private static readonly MIN_FR = 25;
+
   protected readonly johariService = inject(JohariWindowService);
   private readonly insightsService = inject(InsightsService);
 
@@ -244,24 +247,20 @@ export class JohariWindowComponent {
     return `Johari Window: Open ${data.openPercentage}%, Blind Spot ${data.blindSpotPercentage}%, Hidden ${data.hiddenPercentage}%, Unknown ${data.unknownPercentage}%`;
   });
 
-  // Proportional grid sizing — min 25fr ensures small quadrants remain readable
+  // Proportional grid sizing — MIN_FR ensures small quadrants remain readable
   protected readonly gridCols = computed(() => {
     const data = this.johariService.johariWindow();
     if (!data?.hasEnoughData) return '1fr 1fr';
-    const leftPct = data.openPercentage + data.hiddenPercentage;
-    const rightPct = data.blindSpotPercentage + data.unknownPercentage;
-    const left = leftPct === 0 ? 25 : Math.max(25, leftPct);
-    const right = rightPct === 0 ? 25 : Math.max(25, rightPct);
+    const left = Math.max(JohariWindowComponent.MIN_FR, data.openPercentage + data.hiddenPercentage);
+    const right = Math.max(JohariWindowComponent.MIN_FR, data.blindSpotPercentage + data.unknownPercentage);
     return `${left}fr ${right}fr`;
   });
 
   protected readonly gridRows = computed(() => {
     const data = this.johariService.johariWindow();
     if (!data?.hasEnoughData) return '1fr 1fr';
-    const topPct = data.openPercentage + data.blindSpotPercentage;
-    const bottomPct = data.hiddenPercentage + data.unknownPercentage;
-    const top = topPct === 0 ? 25 : Math.max(25, topPct);
-    const bottom = bottomPct === 0 ? 25 : Math.max(25, bottomPct);
+    const top = Math.max(JohariWindowComponent.MIN_FR, data.openPercentage + data.blindSpotPercentage);
+    const bottom = Math.max(JohariWindowComponent.MIN_FR, data.hiddenPercentage + data.unknownPercentage);
     return `${top}fr ${bottom}fr`;
   });
 


### PR DESCRIPTION
## Summary
- **Radar chart labels clipped**: The SVG viewBox (`300×260`) was too narrow, causing "Observer", "Challenger", and other labels to overflow the edges. Expanded viewBox to `340×270` and recentered the hexagon to provide adequate margin for all six labels.
- **Johari Window small quadrants unreadable**: With extreme data (e.g. Open 79%, Blind Spot 5%), the proportional grid minimum of `5fr` made small quadrants ~5% width — too tiny to read. Increased minimum to `25fr` (~21% of axis), reduced grid height to 160px, and made quadrant cells more compact for a cleaner layout.

## Test plan
- [x] All 613 unit tests pass
- [x] All 25 E2E tests pass
- [x] Verified radar chart labels fully visible in browser (all 6 archetypes)
- [x] Verified Johari Window quadrants readable with extreme data (79/5/16/0)
- [x] Measured DOM elements — no text overflow in any quadrant cell

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted communication profile visuals: updated skeleton and radar sizing, made radar responsive, and repositioned labels for improved clarity.
  * Refined Johari window layout: tightened grid spacing and tile padding, reduced type sizes for subtitles, and enforced minimum grid proportions for better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->