### PR TITLE
Fix Google OAuth login failing in production

### DIFF
--- a/src/PraxisNote.Web/ClientApp/ngsw-config.json
+++ b/src/PraxisNote.Web/ClientApp/ngsw-config.json
@@ -3,7 +3,8 @@
   "index": "/index.html",
   "navigationUrls": [
     "/**",
-    "!/signin-google"
+    "!/signin-google",
+    "!/signin-google/**"
   ],
   "assetGroups": [
     {


### PR DESCRIPTION
## Summary
- The Angular service worker (`ngsw`) was intercepting the `/signin-google` OAuth callback navigation request in production and serving cached `index.html` instead of letting it reach the .NET backend
- Added `navigationUrls` exclusion for `/signin-google` in `ngsw-config.json` so the OAuth callback passes through to the server
- Root cause confirmed by observing `NG04002: 'signin-google'` error in browser console and the `/signin-google` request returning HTTP 200 (cached `index.html`) instead of a redirect

## Test plan
- [x] All 625 unit tests pass
- [x] All 25 E2E tests pass
- [ ] Deploy to Cloud Run and verify Google OAuth login works end-to-end
- [ ] Verify existing service worker users get the updated ngsw config on next visit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated service worker navigation configuration to enable navigation handling for all routes while excluding the Google sign-in route from service worker management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->