### PR TITLE
Fix meeting creation failing with non-UTC timezone offset

### DIFF
--- a/src/PraxisNote.Domain/Aggregates/Meetings/Meeting.cs
+++ b/src/PraxisNote.Domain/Aggregates/Meetings/Meeting.cs
@@ -138,7 +138,7 @@ public sealed class Meeting : AggregateRoot
 
         UserId = userId;
         Title = string.IsNullOrWhiteSpace(title) ? null : title.Trim();
-        MeetingDate = meetingDate ?? now;
+        MeetingDate = meetingDate?.ToUniversalTime() ?? now;
         Attendees = string.IsNullOrWhiteSpace(attendees) ? null : attendees.Trim();
         Status = MeetingStatus.Draft;
         CreatedAt = now;
@@ -200,10 +200,11 @@ public sealed class Meeting : AggregateRoot
     /// </summary>
     public void UpdateMeetingDate(DateTimeOffset? meetingDate)
     {
-        if (MeetingDate == meetingDate)
+        var utcDate = meetingDate?.ToUniversalTime();
+        if (MeetingDate == utcDate)
             return;
 
-        MeetingDate = meetingDate;
+        MeetingDate = utcDate;
         UpdatedAt = DateTimeOffset.UtcNow;
     }
 

--- a/tests/PraxisNote.Domain.Tests/Aggregates/MeetingTests.cs
+++ b/tests/PraxisNote.Domain.Tests/Aggregates/MeetingTests.cs
@@ -83,6 +83,20 @@ public class MeetingTests
     }
 
     [Fact]
+    public void Create_WithNonUtcMeetingDate_ConvertsToUtc()
+    {
+        // Arrange - simulate a browser sending AEST (+10:00)
+        var aestDate = new DateTimeOffset(2026, 2, 6, 10, 0, 0, TimeSpan.FromHours(10));
+
+        // Act
+        var meeting = Meeting.Create(_validUserId, _validTitle, aestDate);
+
+        // Assert - should be stored as UTC (offset 0)
+        Assert.Equal(TimeSpan.Zero, meeting.MeetingDate!.Value.Offset);
+        Assert.Equal(aestDate.UtcDateTime, meeting.MeetingDate.Value.UtcDateTime);
+    }
+
+    [Fact]
     public void Create_SetsCreatedAtAndUpdatedAtToSameValue()
     {
         // Act
@@ -220,6 +234,21 @@ public class MeetingTests
 
         // Assert
         Assert.True(meeting.UpdatedAt >= originalUpdatedAt);
+    }
+
+    [Fact]
+    public void UpdateMeetingDate_WithNonUtcDate_ConvertsToUtc()
+    {
+        // Arrange
+        var meeting = Meeting.Create(_validUserId);
+        var aestDate = new DateTimeOffset(2026, 3, 15, 14, 30, 0, TimeSpan.FromHours(10));
+
+        // Act
+        meeting.UpdateMeetingDate(aestDate);
+
+        // Assert - should be stored as UTC (offset 0)
+        Assert.Equal(TimeSpan.Zero, meeting.MeetingDate!.Value.Offset);
+        Assert.Equal(aestDate.UtcDateTime, meeting.MeetingDate.Value.UtcDateTime);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Fix 500 error when creating or updating meetings from non-UTC timezones
- Npgsql requires `DateTimeOffset` values to have UTC offset (0) when writing to PostgreSQL `timestamp with time zone` columns
- The frontend sends meeting dates with the user's local timezone offset (e.g. `+10:00` for AEST), which Npgsql rejects
- Convert meeting dates to UTC via `ToUniversalTime()` in both `Meeting.Create` and `UpdateMeetingDate`

## Root Cause
Cloud Run logs showed:
```
System.ArgumentException: Cannot write DateTimeOffset with Offset=10:00:00
to PostgreSQL type 'timestamp with time zone', only offset 0 (UTC) is supported.
```

## Test plan
- [x] Added unit test: `Create_WithNonUtcMeetingDate_ConvertsToUtc`
- [x] Added unit test: `UpdateMeetingDate_WithNonUtcDate_ConvertsToUtc`
- [x] All 627 unit tests pass
- [x] All 25 E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Meeting dates now consistently stored in UTC format to ensure proper handling across different timezones.

* **Tests**
  * Added tests verifying UTC conversion behavior for meeting creation and date updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->