### PR TITLE
Improve PR skill with lessons learned

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -24,7 +24,7 @@ Check if any changes in this PR require documentation updates:
 
 If updates are needed, make them and commit before proceeding.
 
-## Step 2.5: Generate Feature Notification (Optional)
+## Step 3: Generate Feature Notification (Optional)
 
 If this PR includes user-facing changes (new features, bug fixes, or improvements), ask the user:
 "Would you like to notify users about this change? (Run /broadcast)"
@@ -37,23 +37,62 @@ Skip this step for:
 - Documentation updates
 - CI/workflow changes
 
-## Step 3: Run Tests
+## Step 4: Build and Test
+
+### 4a: Build
+
+Run `dotnet build` to verify the project compiles. If it fails (e.g., missing packages), run `dotnet restore` first, then retry. Fix any compilation errors before proceeding.
+
+### 4b: Run Tests
 
 Run these checks and **ensure they pass**:
 
-1. **Unit tests**: Execute `dotnet test` - expect 185+ tests, all must pass
-2. **E2E tests**: Execute `cd tests/PraxisNote.E2E.Tests && npm test` - all tests must pass
+1. **Unit tests**: Execute `dotnet test` — all tests must pass
+2. **E2E tests**:
+   - First ensure the E2E Docker profile is running: `docker compose --profile e2e up -d --wait`
+   - Then execute: `cd tests/PraxisNote.E2E.Tests && npm test` — all tests must pass
 
 **STOP if any tests fail.** Fix the failures and re-run until all tests pass. Do not proceed to PR creation with failing tests.
 
-## Step 4: Create the PR
+## Step 5: Self Code Review
 
-Once tests pass:
+Review the full diff against the base branch using `git diff main...HEAD` and look for:
+
+### Code Quality
+- Code duplication that could be extracted (DRY principle)
+- Performance improvements without added complexity
+- Patterns that don't match existing codebase conventions
+- Missing null guards or error handling
+
+### Security
+- Missing `rel="noreferrer"` on external links (`target="_blank"`)
+- Unsanitized user input
+- Exposed secrets or credentials
+
+### Frontend
+- Race conditions in async service calls (e.g., stale responses overwriting newer ones)
+- Timezone-safe date handling (use `new Date(year, month - 1, day)` for date-only strings, not `new Date(dateString)` which applies timezone offsets)
+- Invalid date guards (check `isNaN(d.getTime())` before using parsed dates)
+- Accessibility issues (missing `aria-label` on icon-only buttons, semantic HTML)
+
+### Backend
+- EF Core: JSON value conversion properties (e.g., `HashSet<Guid>`) cannot use `.Contains()` in LINQ-to-SQL — must filter in memory
+- EF Core: `DbContext` is NOT thread-safe — never use `Task.WhenAll` with multiple repository calls sharing the same scoped DbContext
+- **Migration safety** (if migrations are included):
+  - No migrations that exist in `main` branch were modified (merged migrations are immutable)
+  - New migrations have been reviewed for accuracy (especially renames vs drop+add)
+  - Destructive changes (DROP TABLE, DROP COLUMN) have been evaluated for data loss
+
+**Apply all fixes now.** Don't defer them — fix issues before creating the PR so reviewers see a clean initial diff. Commit fixes before proceeding.
+
+## Step 6: Create the PR
+
+Once tests pass and self-review fixes are committed:
 
 1. Push any remaining commits to the remote branch
 2. Create the PR using `gh pr create`
 
-## Step 5: Browser Validation (While CI Runs)
+## Step 7: Browser Validation (While CI Runs)
 
 **Purpose**: Validate UI changes work correctly and capture visual evidence for review.
 
@@ -66,7 +105,7 @@ Once tests pass:
 
 1. **Start the dev stack**: Run `docker compose --profile dev-stack up -d`
 2. **Wait for startup**: Wait for the app to be available at http://localhost:4200
-3. **Navigate to the app**: Use the browser automation tools to open the app
+3. **Write a Playwright validation script**: Create a script in `tests/PraxisNote.E2E.Tests/` (where Playwright is installed) that uses Playwright to navigate to the app and capture screenshots. For PrimeNG components like dropdowns, interact with them directly (click to open, type to filter, click to select) rather than relying on URL query parameters.
 4. **Capture before/after screenshots** (for refactoring PRs):
    - If this is a refactoring PR with no expected visual changes, take screenshots BEFORE making changes (from main branch) and AFTER
    - Compare to verify no unintended visual differences
@@ -78,11 +117,12 @@ Once tests pass:
    - Test both light and dark mode if styling is involved (screenshot both)
    - Check responsive behavior if layout changes are involved
    - Test keyboard navigation if interactive elements are added
-6. **Add screenshots to PR**: 
+6. **Add screenshots to PR**:
    - Use `gh pr comment` to add screenshots showing the UI works
    - For refactoring: "No visual changes - before/after comparison attached"
    - For new features: "Feature working as expected - screenshots attached"
-7. **Fix any issues**: If something doesn't work or looks wrong, fix it, commit, push, and re-run tests
+7. **Clean up**: Delete any temporary validation scripts after screenshots are captured
+8. **Fix any issues**: If something doesn't work or looks wrong, fix it, commit, push, and re-run tests
 
 **Screenshot requirements by PR type**:
 | PR Type | Required Screenshots |
@@ -92,40 +132,31 @@ Once tests pass:
 | Bug fix with UI impact | Fixed state showing correct behavior |
 | Styling/theming changes | Light mode + dark mode + mobile viewport |
 
-**If UI validation fails**: Fix the issue, commit, push, and restart from Step 3.
+**If UI validation fails**: Fix the issue, commit, push, and restart from Step 4.
 
-## Step 6: Post-PR Review and Monitoring
+## Step 8: Post-PR Monitoring and Review Comments
 
 After the PR is created, **actively monitor** and address feedback:
 
-1. **Self code review**: Review the PR diff using `gh pr diff` and look for:
-   - Code duplication that could be extracted (DRY principle)
-   - Performance improvements without added complexity
-   - Patterns that don't match existing codebase conventions
-   - Missing null guards or error handling
-   - Accessibility issues (missing aria-labels on icon-only buttons)
-   - **Migration safety** (if migrations are included):
-     - No migrations that exist in `main` branch were modified (merged migrations are immutable)
-     - New migrations have been reviewed for accuracy (especially renames vs drop+add)
-     - Destructive changes (DROP TABLE, DROP COLUMN) have been evaluated for data loss
-
-   **Apply good refactoring opportunities** you identify - don't defer them to future PRs unless they require significant architectural changes. Add comments for any issues found using `gh pr comment` or `gh api`
-2. **Wait for CI**: Monitor GitHub Actions for completion using `gh pr checks`
-3. **Check for warnings**: Review action logs AND annotations for any warnings (not just failures)
+1. **Wait for CI**: Monitor GitHub Actions for completion using `gh pr checks`
+2. **Check for warnings**: Review action logs AND annotations for any warnings (not just failures)
    - Use `gh api repos/{owner}/{repo}/check-runs/{job_id}/annotations` to fetch annotations
    - Common warnings: deprecation notices, bundle size budgets, artifact upload failures, EF Core model validation
    - **ALL warnings must be addressed** - either fix the issue or update the workflow if it's a false positive
-4. **Monitor for AI reviews**: Actively poll for CodeRabbit and Copilot reviews to complete
+3. **Monitor for AI reviews**: Actively poll for CodeRabbit and Copilot reviews to complete
    - **CodeRabbit**: Use `gh pr checks` - wait until CodeRabbit shows "Review completed"
    - **Copilot**: Use `gh api repos/{owner}/{repo}/pulls/{number}/reviews --jq '.[] | select(.user.login | contains("copilot")) | .state'` to check if Copilot has submitted a review (look for "COMMENTED" state)
    - Alternatively, use `gh pr view <number> --comments` and look for comments from `copilot-pull-request-reviewer[bot]`
-   - Keep checking every 30-60 seconds until BOTH CodeRabbit AND Copilot reviews are complete
-5. **Address all comments immediately**: When comments appear:
+   - Keep checking every 5 minutes until BOTH CodeRabbit AND Copilot reviews are complete
+4. **Address all comments immediately**: When comments appear:
    - Read each comment carefully, including **high-level feedback** in comment bodies (not just line-specific suggestions)
    - **For line comments (have their own ID)**:
      - **If addressing**: Add a thumbs up reaction using `gh api repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions -X POST -f content='+1'`, then make the fix
      - **If not addressing**: Reply to the comment explaining why (must be a strong justification - see below)
    - **For high-level feedback in PR comments**: Reply to the comment addressing each suggestion
+
+   **IMPORTANT - Batch Review Fixes**:
+   Address ALL comments from a review round before committing. Collect all fixes, apply them, then commit and push once. This minimizes review cycles — each push triggers a new round of AI reviews, so fewer pushes means faster convergence.
 
    **IMPORTANT - No Deferring Valid Comments**:
    Valid review comments must be addressed in the current PR. Do NOT:
@@ -140,23 +171,25 @@ After the PR is created, **actively monitor** and address feedback:
    - The reviewer explicitly marked it as "nit" or "optional"
 
    If you find yourself wanting to defer, ask: "Can I fix this in under 30 minutes?" If yes, fix it now.
-6. **Verify CI passes**: After all fixes, ensure all checks pass (no warnings in annotations)
-7. **Wait for re-reviews after pushing fixes**: Every time you push new commits (from self-review fixes, addressing reviewer comments, or any other changes), you MUST restart the review monitoring loop:
+5. **Verify CI passes**: After all fixes, ensure all checks pass (no warnings in annotations)
+6. **Wait for re-reviews after pushing fixes**: Every time you push new commits (from addressing reviewer comments or any other changes), you MUST restart the review monitoring loop:
    - Note the SHA of the latest commit you pushed
    - **Wait for Copilot to re-review the new commit**: Poll using `gh api repos/{owner}/{repo}/pulls/{number}/reviews --jq '.[] | select(.user.login | contains("copilot")) | {state, commit_id: .commit_id}'` and verify a review exists for the latest commit SHA. Copilot reviews against older commits do NOT count.
    - **Wait for CodeRabbit**: Check `gh pr checks` until CodeRabbit shows "Review completed"
-   - **Address any new comments** from the re-review (repeat steps 5-7 as needed)
+   - **NEVER give up polling**: If a reviewer has not reviewed the latest commit yet, keep polling every 5 minutes. Do NOT declare the PR ready or move to the next step while any reviewer's re-review is still pending. If a reviewer has not responded after 1 hour of polling, inform the user and ask whether to continue waiting — but do NOT skip the review or assume no new comments will appear. Abandoning the polling loop early risks missing new review comments.
+   - **Re-fetch ALL line-level comments**: After reviewers have reviewed the latest commit, fetch the full comment list using `gh api repos/{owner}/{repo}/pulls/{number}/comments` and check for any comments posted since your last comment check. Reviewers may post new comments on intermediate commits while you are working on fixes — checking only the review status is NOT sufficient. You must compare timestamps to find comments you haven't addressed yet.
+   - **Address any new comments** from the re-review (repeat steps 4-6 as needed)
    - This loop continues until: the latest pushed commit has been reviewed by ALL reviewers, all comments are addressed, and CI is green
 
-**Do not stop monitoring until**: The latest commit has been reviewed by ALL AI reviewers (both CodeRabbit AND Copilot must have reviews against the most recent commit SHA), all comments are addressed, and CI is green. It is NOT sufficient that reviewers reviewed an earlier commit — they must review the final state of the code.
+**Do not stop monitoring until**: The latest commit has been reviewed by ALL AI reviewers (both CodeRabbit AND Copilot must have reviews against the most recent commit SHA), all line-level comments have been fetched and addressed (not just review status checked), and CI is green. It is NOT sufficient that reviewers reviewed an earlier commit — they must review the final state of the code.
 
-## Step 7: User Approval and Merge
+## Step 9: User Approval and Merge
 
 Once CI is green and all comments are addressed:
 
 1. **Notify the user**: Tell them the PR is ready for their review and approval
 2. **Wait for approval**: Do NOT merge until the user explicitly approves
-3. **If feedback given**: Make fixes, commit, push, and repeat from Step 3 (tests + browser validation)
+3. **If feedback given**: Make fixes, commit, push, and repeat from Step 4 (build, tests + browser validation)
 4. **If approved**: Proceed to merge with `gh pr merge --squash --delete-branch`
 
 **Exception**: For markdown-only PRs (`.md` files only), merge immediately without waiting for user approval.


### PR DESCRIPTION
## Summary
- Move self-review before PR creation for cleaner initial diffs
- Add build step (`dotnet build`/`dotnet restore`) before running tests
- Add E2E Docker prerequisite (`docker compose --profile e2e`)
- Remove hardcoded test count (was stale at 185+)
- Add batch review fixes guidance to reduce review cycles
- Expand self-review checklist with security, frontend, and backend sections
- Specify Playwright for browser validation scripts
- Renumber steps sequentially (no more Step 2.5)
- Add never-give-up-polling rule for reviewer re-reviews
- Add re-fetch line-level comments after each push

## Test plan
- [x] Markdown-only change — no runtime impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)