### PR TITLE
Fix notification datetime mismatch (#374)

### DIFF
--- a/src/PraxisNote.Web/ClientApp/src/app/notifications/notification-panel.component.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/notifications/notification-panel.component.ts
@@ -107,7 +107,7 @@ import { NotificationService } from './notification.service';
                           </p>
                           <div class="flex items-center gap-3 mt-2">
                             <span class="text-xs text-foreground-muted">
-                              {{ notification.createdAt | date:'MMM d, yyyy' }}
+                              {{ notification.createdAt | date:'MMM d, yyyy':'UTC' }}
                             </span>
                             @if (notification.issueUrl) {
                               <a


### PR DESCRIPTION
## Summary
- Force `DatePipe` to use UTC timezone when formatting notification dates, preventing late-UTC timestamps from rolling over to the next calendar day for users in timezones ahead of UTC (e.g., AEST at UTC+10/11)
- A notification with `CreatedAt = 2026-02-06T16:00:00Z` now always shows "Feb 6, 2026" regardless of the user's local timezone

## Test plan
- [x] Unit tests pass (673 tests)
- [x] E2E tests pass (25 tests)
- [ ] Verify notification dates display correctly in UTC for all timezones

Closes #374

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Fix notification date display so that created-at timestamps consistently show the correct calendar day regardless of the user’s local timezone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated notification date display to consistently show times in UTC timezone, ensuring accurate time representation across all regions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->