### PR TITLE
Change tag item links to in-app navigation

### DIFF
--- a/src/PraxisNote.Web/ClientApp/src/app/tags/tags.page.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/tags/tags.page.ts
@@ -283,9 +283,9 @@ interface DateGroup {
                       <div class="flex items-center gap-2 shrink-0">
                         <span class="text-xs text-foreground-muted">{{ relativeDate(item.date) }}</span>
                         <button
+                          type="button"
                           class="p-1 rounded hover:bg-surface text-foreground-muted opacity-0 group-hover:opacity-100 transition-opacity"
                           (click)="openInNewTab(item, $event)"
-                          (keydown.enter)="openInNewTab(item, $event)"
                           aria-label="Open in new tab"
                         >
                           <i class="pi pi-external-link text-xs" aria-hidden="true"></i>
@@ -594,7 +594,7 @@ export class TagsPage implements OnInit {
 
   openInNewTab(item: TagItemDto, event: Event): void {
     event.stopPropagation();
-    window.open(this.itemUrl(item), '_blank');
+    window.open(this.itemUrl(item), '_blank', 'noopener,noreferrer');
   }
 
   formatMeetingMeta(item: TagItemDto): string {


### PR DESCRIPTION
## Summary
- Tag page item clicks now navigate in-app (same tab) instead of opening a new browser tab
- An explicit "open in new tab" icon button appears on hover for each item, with `stopPropagation` to avoid double navigation
- Touch device support: new-tab button is always visible on devices without hover

Closes #368

## Test plan
- [x] All 673 unit tests pass
- [x] All 25 E2E tests pass
- [ ] Verify clicking a Task/Note/Meeting on the Tags page navigates in-app
- [ ] Verify the external-link icon button opens in a new tab without also triggering in-app navigation
- [ ] Verify keyboard navigation (Enter to navigate, Enter on icon button to open in new tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update tag page item interactions to use in-app navigation by default with an explicit control to open items in a new browser tab.

New Features:
- Allow tag page items to be opened in a new browser tab via a dedicated icon button that does not trigger in-app navigation.

Enhancements:
- Change tag page item clicks and keyboard activation to navigate in-app using the router instead of opening a new browser tab.
- Improve accessibility of tag page items by using focusable link-like containers with keyboard support for both in-app navigation and opening in a new tab.
- Ensure the new-tab button remains visible on non-hover (touch) devices for tag page items.