### PR TITLE
Rename Tags to Tag Hub in sidebar and page header

### DIFF
--- a/src/PraxisNote.Web/ClientApp/src/app/shared/sidebar/sidebar.component.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/shared/sidebar/sidebar.component.ts
@@ -107,7 +107,7 @@ export class SidebarComponent implements OnInit {
     { path: '/tasks', label: 'Tasks', icon: 'pi-check-square', enabled: true },
     { path: '/meetings', label: 'Meetings', icon: 'pi-comments', enabled: true },
     { path: '/insights', label: 'Insights', icon: 'pi-chart-line', enabled: true },
-    { path: '/tags', label: 'Tags', icon: 'pi-tags', enabled: true },
+    { path: '/tags', label: 'Tag Hub', icon: 'pi-tags', enabled: true },
   ];
 
   ngOnInit(): void {

--- a/src/PraxisNote.Web/ClientApp/src/app/tags/tags.page.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/tags/tags.page.ts
@@ -49,7 +49,7 @@ interface DateGroup {
       <!-- Header -->
       <div class="flex items-center gap-3 mb-6">
         <i class="pi pi-tags text-lg text-foreground-secondary" aria-hidden="true"></i>
-        <h1 class="text-lg font-semibold text-foreground">Tags</h1>
+        <h1 class="text-lg font-semibold text-foreground">Tag Hub</h1>
         @if (!tagService.loading() && !tagService.error()) {
           <span class="text-sm text-foreground-muted">{{ tagCount() }} tags</span>
         }


### PR DESCRIPTION
## Summary

- Rename sidebar navigation label from "Tags" to "Tag Hub"
- Rename page heading from "Tags" to "Tag Hub"
- Route path `/tags` remains unchanged for URL stability

Closes #394

## Test plan

- [x] Unit tests pass (673/673)
- [x] E2E tests pass (25/25)
- [ ] Verify sidebar shows "Tag Hub" label
- [ ] Verify tags page header shows "Tag Hub"
- [ ] Verify route remains `/tags`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Rename the tags section UI copy from "Tags" to "Tag Hub" in navigation and the tags page header.

Enhancements:
- Update sidebar navigation label for the /tags route from "Tags" to "Tag Hub".
- Update the tags page main heading text to "Tag Hub" to match the new naming in the UI.