### PR TITLE
Show tag kebab menu at 30% opacity instead of hidden (#395)

### DIFF
--- a/src/PraxisNote.Web/ClientApp/src/app/tags/tags.page.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/tags/tags.page.ts
@@ -128,7 +128,7 @@ interface DateGroup {
                   <span class="ml-auto text-xs text-foreground-muted mr-2">{{ tag.usageCount }}</span>
                   <button
                     type="button"
-                    class="w-6 h-6 flex items-center justify-center rounded text-foreground-muted opacity-30 group-hover/tag:opacity-100 hover:bg-surface-muted transition-opacity"
+                    class="w-6 h-6 flex items-center justify-center rounded text-foreground-muted opacity-30 group-hover/tag:opacity-100 focus-visible:opacity-100 hover:bg-surface-muted transition-opacity"
                     (click)="showTagActions($event, tag)"
                     aria-label="Actions for tag {{ tag.name }}">
                     <i class="pi pi-ellipsis-v text-xs"></i>


### PR DESCRIPTION
## Summary

- Change tag kebab (3-dot) menu button from invisible (`opacity-0`) to subtle (`opacity-30`), transitioning to full opacity on hover
- Remove the `@media (hover: none)` touch-device workaround for `.group\/tag button` since base opacity now ensures visibility on all devices

## Test plan

- [x] Unit tests pass (673 tests)
- [x] E2E tests pass (25 tests)
- [ ] Verify kebab dots are visible at reduced opacity on all tag rows without hovering
- [ ] Verify kebab dots transition to full opacity on hover
- [ ] Verify touch devices still show the dots (handled by base `opacity-30`)
- [ ] Verify clicking kebab still opens the rename/delete/merge action menu

Closes #395

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Adjust tag action menu visibility to remain subtly visible by default while still highlighting on hover

Enhancements:
- Make the tag kebab menu icon partially visible by default instead of fully hidden, improving discoverability across devices
- Simplify hover-related styles by removing a touch-device-specific opacity override now that the button is always visible