### PR TITLE
Fix toast close button circular border display (#402)

### DIFF
--- a/src/PraxisNote.Web/ClientApp/src/styles.css
+++ b/src/PraxisNote.Web/ClientApp/src/styles.css
@@ -850,11 +850,11 @@
   width: 1.75rem !important;
   height: 1.75rem !important;
   margin: 0 !important;
-  right: 0 !important;
+  inset-inline-end: 0 !important;
 }
 
 .p-toast-message .p-toast-close-button:focus-visible {
-  outline: 2px solid currentColor !important;
+  outline: 2px solid var(--color-primary-solid) !important;
   outline-offset: 2px !important;
   box-shadow: none !important;
 }


### PR DESCRIPTION
## Summary

- Updated toast close button CSS selectors from old PrimeNG v17 class names (`.p-toast-icon-close`) to PrimeNG v21 class names (`.p-toast-close-button`, `.p-toast-close-icon`)
- Removed circular border/outline styling and replaced with a minimal rounded square close button
- Added proper dark mode hover state using `[data-theme="dark"]` selector

Closes #402

## Test plan

- [ ] Verify close button renders as a minimal X icon without circular border/outline
- [ ] Verify subtle hover state (light background highlight) in both light and dark themes
- [ ] Verify close button is properly positioned within the toast
- [ ] Verify close button remains keyboard-accessible (Enter/Space to dismiss)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced toast notification close button with improved visual feedback on hover and focus interactions, including accessible outline styling for better keyboard navigation support.
  * Added dark theme support with theme-specific styling for close button hover states.
  * Refined close icon sizing for consistent appearance across themes and screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->