### PR TITLE
Add success toast when disconnecting Google Calendar

### DIFF
--- a/src/PraxisNote.Web/ClientApp/src/app/settings/calendar.service.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/settings/calendar.service.ts
@@ -60,6 +60,10 @@ export class CalendarService {
     });
   }
 
+  acknowledgeDisconnected(): void {
+    this._lastDisconnected.set(false);
+  }
+
   disconnectCalendar(): void {
     this._loading.set(true);
     this._error.set(null);

--- a/src/PraxisNote.Web/ClientApp/src/app/settings/settings.page.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/settings/settings.page.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, inject, OnInit, OnDestroy, effect } from '@angular/core';
+import { Component, ChangeDetectionStrategy, inject, OnInit, OnDestroy, effect, untracked } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { DatePipe } from '@angular/common';
 import { Button } from 'primeng/button';
@@ -132,7 +132,10 @@ export class SettingsPage implements OnInit, OnDestroy {
     // Show toast when calendar is disconnected successfully
     effect(() => {
       if (this.calendarService.lastDisconnected()) {
-        this.toast.success({ summary: 'Google Calendar disconnected.' });
+        untracked(() => {
+          this.toast.success({ summary: 'Google Calendar disconnected.' });
+          this.calendarService.acknowledgeDisconnected();
+        });
       }
     });
   }


### PR DESCRIPTION
## Summary
- Add `lastDisconnected` signal to `CalendarService` that fires on successful disconnect
- Add `effect()` in `SettingsPage` to show "Google Calendar disconnected." toast when signal fires
- Follows the same signal + effect pattern already used for sync results

Closes #404

## Test plan
- [x] Unit tests pass (695/695)
- [x] E2E tests pass (25/25)
- [x] Toast does not appear on initial page load (signal starts as `false`)
- [x] Toast does not appear on error (only set in `next` callback)
- [x] Error toast still works on disconnect failure (existing behavior preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Show a success toast when a Google Calendar disconnect operation completes successfully.

New Features:
- Expose a reactive lastDisconnected signal on CalendarService to track successful calendar disconnections.
- Display a "Google Calendar disconnected." toast on the settings page when a disconnect completes successfully.