### PR TITLE
Fix meeting detail page inconsistent padding (#409)

### DIFF
--- a/src/PraxisNote.Web/ClientApp/src/app/meetings/meeting-editor.page.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/meetings/meeting-editor.page.ts
@@ -83,7 +83,7 @@ interface DateOption {
             </button>
           </div>
         } @else {
-          <div class="editor-wrapper">
+          <div class="max-w-6xl mx-auto px-6 md:px-8 py-8 md:py-10">
             <!-- Title -->
             <div class="title-row">
               <input
@@ -542,9 +542,6 @@ interface DateOption {
 
     .editor-container { flex: 1; overflow: auto; }
     .loading, .not-found { display: flex; flex-direction: column; align-items: center; justify-content: center; height: 100%; }
-    .editor-wrapper { max-width: 80rem; margin: 0 auto; width: 100%; padding: 1.5rem; box-sizing: border-box; }
-    @media (max-width: 768px) { .editor-wrapper { padding: 1rem; } }
-
     .title-row { display: flex; align-items: center; gap: 8px; margin-bottom: 20px; }
     .title-input {
       font-size: 22px; font-weight: 700; border: none; background: transparent;


### PR DESCRIPTION
## Summary

- Replace custom `.editor-wrapper` CSS (80rem max-width, 1.5rem padding) with standard Tailwind utilities (`max-w-6xl mx-auto px-6 md:px-8 py-8 md:py-10`) to match all other pages
- Remove unused `.editor-wrapper` CSS rule and its `@media` query from the component styles

Closes #409

## Test plan

- [x] Unit tests pass (695/695)
- [x] E2E tests pass (25/25)
- [ ] Verify meeting detail page padding matches meetings list page
- [ ] Verify content aligns visually when navigating between list and detail
- [ ] Verify mobile padding is consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align meeting detail editor layout and spacing with the standard page container used elsewhere in the app.

Enhancements:
- Replace the custom meeting editor wrapper with shared Tailwind layout utilities for consistent width and padding across pages.
- Remove now-unused editor-specific CSS and media query styles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the meeting editor page layout with improved utility-based styling. The change modernizes the container design and enhances consistency with the application's design system, with no impact to functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->