### PR TITLE
Add accessibility markup to remaining loading states (#417)

### DIFF
--- a/src/PraxisNote.Web/ClientApp/src/app/insights/goals-section.component.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/insights/goals-section.component.ts
@@ -32,7 +32,8 @@ import { ErrorStateComponent } from '../shared/components/error-state.component'
       </div>
 
       @if (goalsService.loading()) {
-        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4" role="status" aria-label="Loading goals">
+          <span class="sr-only">Loading goals...</span>
           @for (i of skeletonItems; track i) {
             <div class="bg-surface-subtle border border-border rounded-xl p-4">
               <div class="flex items-center gap-3">

--- a/src/PraxisNote.Web/ClientApp/src/app/insights/insights.page.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/insights/insights.page.ts
@@ -34,23 +34,26 @@ import { ErrorStateComponent } from '../shared/components/error-state.component'
 
       @if (insightsService.loading()) {
         <!-- Skeleton loading state -->
-        <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-4 mb-6">
-          @for (i of skeletonCards; track i) {
-            <div class="bg-surface-subtle border border-border rounded-xl p-4">
-              <p-skeleton width="60%" height="12px" styleClass="mb-3" />
-              <p-skeleton width="40%" height="28px" styleClass="mb-2" />
-              <p-skeleton width="80%" height="10px" />
-            </div>
-          }
-        </div>
-        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-          @for (i of skeletonCharts; track i) {
-            <div class="bg-surface-subtle border border-border rounded-xl p-4">
-              <p-skeleton width="50%" height="12px" styleClass="mb-2" />
-              <p-skeleton width="30%" height="24px" styleClass="mb-3" />
-              <p-skeleton width="100%" height="64px" />
-            </div>
-          }
+        <div role="status" aria-label="Loading insights">
+          <span class="sr-only">Loading insights...</span>
+          <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-4 mb-6">
+            @for (i of skeletonCards; track i) {
+              <div class="bg-surface-subtle border border-border rounded-xl p-4">
+                <p-skeleton width="60%" height="12px" styleClass="mb-3" />
+                <p-skeleton width="40%" height="28px" styleClass="mb-2" />
+                <p-skeleton width="80%" height="10px" />
+              </div>
+            }
+          </div>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            @for (i of skeletonCharts; track i) {
+              <div class="bg-surface-subtle border border-border rounded-xl p-4">
+                <p-skeleton width="50%" height="12px" styleClass="mb-2" />
+                <p-skeleton width="30%" height="24px" styleClass="mb-3" />
+                <p-skeleton width="100%" height="64px" />
+              </div>
+            }
+          </div>
         </div>
       } @else if (insightsService.error()) {
         <app-error-state

--- a/src/PraxisNote.Web/ClientApp/src/app/summary/summary.page.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/summary/summary.page.ts
@@ -51,23 +51,26 @@ import { ErrorStateComponent } from '../shared/components/error-state.component'
 
       @if (summaryService.loading()) {
         <!-- Skeleton loading state -->
-        <div class="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-6">
-          @for (i of skeletonCards; track i) {
-            <div class="bg-surface-subtle border border-border rounded-xl p-4 text-center">
-              <p-skeleton width="40%" height="28px" styleClass="mb-2 mx-auto" />
-              <p-skeleton width="60%" height="10px" styleClass="mx-auto" />
-            </div>
-          }
-        </div>
-        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-4">
-          @for (i of skeletonSections; track i) {
-            <div class="bg-surface-subtle border border-border rounded-xl p-4">
-              <p-skeleton width="40%" height="14px" styleClass="mb-3" />
-              <p-skeleton width="100%" height="12px" styleClass="mb-2" />
-              <p-skeleton width="90%" height="12px" styleClass="mb-2" />
-              <p-skeleton width="80%" height="12px" />
-            </div>
-          }
+        <div role="status" aria-label="Loading daily summary">
+          <span class="sr-only">Loading daily summary...</span>
+          <div class="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-6">
+            @for (i of skeletonCards; track i) {
+              <div class="bg-surface-subtle border border-border rounded-xl p-4 text-center">
+                <p-skeleton width="40%" height="28px" styleClass="mb-2 mx-auto" />
+                <p-skeleton width="60%" height="10px" styleClass="mx-auto" />
+              </div>
+            }
+          </div>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-4">
+            @for (i of skeletonSections; track i) {
+              <div class="bg-surface-subtle border border-border rounded-xl p-4">
+                <p-skeleton width="40%" height="14px" styleClass="mb-3" />
+                <p-skeleton width="100%" height="12px" styleClass="mb-2" />
+                <p-skeleton width="90%" height="12px" styleClass="mb-2" />
+                <p-skeleton width="80%" height="12px" />
+              </div>
+            }
+          </div>
         </div>
       } @else if (summaryService.error()) {
         <app-error-state


### PR DESCRIPTION
## Summary
- Add `role="status"`, `aria-label`, and `<span class="sr-only">` text to skeleton loading sections that were missing accessibility attributes
- Files fixed: `insights.page.ts`, `summary.page.ts`, `goals-section.component.ts`
- Files already fixed by #414 (verified, not changed): `notification-panel.component.ts`, `settings.page.ts`, `insights-widget.component.ts`

Closes #417

## Test plan
- [x] `dotnet build` compiles without errors or warnings
- [x] All 695 unit tests pass
- [x] All 25 E2E tests pass
- [ ] No visual changes expected -- this is purely adding HTML attributes for screen reader accessibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Improve accessibility of loading skeletons across insights and summary pages by exposing their state to assistive technologies.

New Features:
- Expose loading status for insights skeletons using ARIA roles and screen-reader-only text.
- Expose loading status for summary skeletons using ARIA roles and screen-reader-only text.
- Expose loading status for goals section skeletons using ARIA roles and screen-reader-only text.