### PR TITLE
Fix PWA update banner button using unmapped color tokens (#442)

### DIFF
--- a/src/PraxisNote.Web/ClientApp/src/app/app.html
+++ b/src/PraxisNote.Web/ClientApp/src/app/app.html
@@ -115,7 +115,7 @@
     aria-label="Application update available"
     class="fixed bottom-24 right-4 z-50 bg-surface border border-border rounded-lg shadow-lg p-4 flex items-center gap-3 max-w-sm animate-slide-up"
   >
-    <i class="pi pi-refresh text-xl text-primary shrink-0" aria-hidden="true"></i>
+    <i class="pi pi-refresh text-xl text-accent-foreground shrink-0" aria-hidden="true"></i>
     <div class="flex-1 min-w-0">
       <p class="font-medium text-foreground">Update available</p>
       <p class="text-sm text-foreground-muted">A new version of PraxisNote is ready.</p>
@@ -129,7 +129,7 @@
         Later
       </button>
       <button
-        class="px-3 py-1.5 text-sm font-medium text-white bg-primary hover:bg-primary/90 rounded transition-colors"
+        class="px-3 py-1.5 text-sm font-medium text-white bg-accent-solid hover:bg-accent-solid/90 rounded transition-colors"
         (click)="pwaUpdateService.applyUpdate()"
         aria-label="Update PraxisNote now"
       >


### PR DESCRIPTION
## Summary
- Replace unmapped `text-primary` with `text-accent-foreground` on the PWA update banner refresh icon
- Replace unmapped `bg-primary` / `hover:bg-primary/90` with `bg-accent-solid` / `hover:bg-accent-solid/90` on the Update button
- Ensures the button is visible in both light and dark mode, consistent with all other primary action buttons in the app

Closes #442

## Test plan
- [x] Unit tests pass (695 tests)
- [x] E2E tests pass (25 tests)
- [x] Verified correct semantic tokens (`bg-accent-solid`, `text-accent-foreground`) match established patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align PWA update banner styling with mapped accent semantic tokens for consistent theming in light and dark mode.

Bug Fixes:
- Fix PWA update banner refresh icon and update button using unmapped primary color tokens that could render poorly across themes.

Enhancements:
- Use accent foreground and solid background semantic tokens on the PWA update banner to match the app’s primary action button style.