### PR TITLE
Move transcript card above AI analysis on meeting editor (#453)

### DIFF
--- a/src/PraxisNote.Web/ClientApp/src/app/meetings/meeting-editor.page.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/meetings/meeting-editor.page.ts
@@ -331,40 +331,6 @@ interface DateOption {
             </div>
 
             @if (!isNewMeeting()) {
-              <!-- AI Analysis Section - Green border -->
-              <div class="section-card analysis-card">
-                <div class="section-header analysis-header">
-                  <span><i class="pi pi-sparkles"></i> AI Analysis</span>
-                </div>
-                @if (currentMeeting()) {
-                  <app-meeting-analysis
-                    [meeting]="currentMeeting()!"
-                    [actionItemStatuses]="actionItemStatuses()"
-                    [promotingIds]="promotingIds()"
-                    (onAnalyze)="analyze()"
-                    (onToggleActionItem)="toggleActionItem($event)"
-                    (onPromoteActionItem)="promoteActionItem($event)"
-                    (onNavigateToTask)="navigateToTask($event)"
-                  />
-                } @else {
-                  <div class="empty-analysis">
-                    Click "Generate" to create an AI summary of this meeting
-                  </div>
-                }
-              </div>
-
-              <!-- Reflection Section - Purple border -->
-              @if (currentMeeting()?.behavioralAnalysis) {
-                <div class="section-card reflection-card">
-                  <div class="section-header reflection-header">
-                    <span><i class="pi pi-comments"></i> Self-Reflection</span>
-                  </div>
-                  <app-meeting-reflection
-                    [meeting]="currentMeeting()!"
-                  />
-                </div>
-              }
-
               <!-- Transcript Section - Blue border -->
               <div class="section-card transcript-card">
                 <div class="section-header transcript-header">
@@ -513,6 +479,40 @@ interface DateOption {
                   <span class="text-xs text-foreground-muted">{{ transcript().length }} characters</span>
                 </div>
               </div>
+
+              <!-- AI Analysis Section - Green border -->
+              <div class="section-card analysis-card">
+                <div class="section-header analysis-header">
+                  <span><i class="pi pi-sparkles"></i> AI Analysis</span>
+                </div>
+                @if (currentMeeting()) {
+                  <app-meeting-analysis
+                    [meeting]="currentMeeting()!"
+                    [actionItemStatuses]="actionItemStatuses()"
+                    [promotingIds]="promotingIds()"
+                    (onAnalyze)="analyze()"
+                    (onToggleActionItem)="toggleActionItem($event)"
+                    (onPromoteActionItem)="promoteActionItem($event)"
+                    (onNavigateToTask)="navigateToTask($event)"
+                  />
+                } @else {
+                  <div class="empty-analysis">
+                    Click "Generate" to create an AI summary of this meeting
+                  </div>
+                }
+              </div>
+
+              <!-- Reflection Section - Purple border -->
+              @if (currentMeeting()?.behavioralAnalysis) {
+                <div class="section-card reflection-card">
+                  <div class="section-header reflection-header">
+                    <span><i class="pi pi-comments"></i> Self-Reflection</span>
+                  </div>
+                  <app-meeting-reflection
+                    [meeting]="currentMeeting()!"
+                  />
+                </div>
+              }
             }
           </div>
         }


### PR DESCRIPTION
## Summary
- Reorders section cards on the meeting editor page so the **Transcript** card appears directly below **Details**
- **AI Analysis** and **Self-Reflection** cards now follow the Transcript card
- New order: Details → Transcript → AI Analysis → Self-Reflection
- Pure template reordering — no logic, styles, or component changes

Closes #453

## Test plan
- [x] Unit tests pass (695/695)
- [x] E2E tests pass (25/25)
- [ ] Verify on meeting editor: Transcript card is below Details
- [ ] Verify AI Analysis card is below Transcript
- [ ] Verify Self-Reflection card is below AI Analysis
- [ ] All recording, transcription, analysis, and reflection features work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)