### PR TITLE
Reorder side nav: move Tasks before Notes (#456)

### DIFF
--- a/src/PraxisNote.Web/ClientApp/src/app/shared/sidebar/sidebar.component.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/shared/sidebar/sidebar.component.ts
@@ -103,8 +103,8 @@ export class SidebarComponent implements OnInit {
 
   protected readonly navItems: NavItem[] = [
     { path: '/home', label: 'Home', icon: 'pi-home', enabled: true },
-    { path: '/notes', label: 'Notes', icon: 'pi-file-edit', enabled: true },
     { path: '/tasks', label: 'Tasks', icon: 'pi-check-square', enabled: true },
+    { path: '/notes', label: 'Notes', icon: 'pi-file-edit', enabled: true },
     { path: '/meetings', label: 'Meetings', icon: 'pi-comments', enabled: true },
     { path: '/tags', label: 'Tag Hub', icon: 'pi-tags', enabled: true },
     { path: '/summary', label: 'Summary', icon: 'pi-clock', enabled: true },


### PR DESCRIPTION
## Summary
- Swaps the **Tasks** and **Notes** entries in the sidebar navigation so the order is: Home, Tasks, Notes, Meetings, Tag Hub, Summary, Insights
- Closes #456

## Test plan
- [x] Unit tests pass (695 tests)
- [x] E2E tests pass (25 tests)
- [x] Single-line swap verified in diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the order of navigation items in the sidebar. The Notes section now appears after Tasks for improved organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->