### PR TITLE
Fix toggle section invisible in note editor (#493)

### DIFF
--- a/src/PraxisNote.Web/ClientApp/src/app/notes/tiptap-editor.component.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/notes/tiptap-editor.component.ts
@@ -789,15 +789,16 @@ interface BlockType {
 
     /* Arrow indicator on the toggle button */
     :host ::ng-deep .ProseMirror div[data-type="details"] > button::before {
-      content: "▶ ";
+      content: "▶";
       font-size: 0.75em;
       display: inline-block;
+      margin-right: 0.25em;
       transition: transform 0.15s;
     }
 
-    /* Open state arrow */
+    /* Open state arrow — rotate instead of swapping content */
     :host ::ng-deep .ProseMirror div[data-type="details"].is-open > button::before {
-      content: "▼ ";
+      transform: rotate(90deg);
     }
 
     /* Open state spacing */


### PR DESCRIPTION
## Summary

- Fix CSS selectors in the note editor's toggle section (details/summary) styling to match the actual DOM output from `@tiptap/extension-details` v3.19.0
- The extension renders `<div data-type="details">` with a `<button>` toggle instead of native `<details>`/`<summary>` elements, so the old CSS selectors (`details`, `details summary`) never matched, leaving toggle sections invisible
- Updated all selectors to target `div[data-type="details"]` and styled the toggle button with proper reset styles (no background/border, inherited font) and arrow indicators

Closes #493

## Test plan

- [x] Angular build compiles without errors
- [x] .NET build compiles without errors
- [x] All 776 unit tests pass (510 Domain + 266 Application)
- [x] All 25 E2E tests pass
- [ ] Manual: Insert a Toggle Section via toolbar → verify it appears with accent left border, rounded corners, and subtle background
- [ ] Manual: Click the toggle button → verify content area shows/hides with arrow changing between ▶ and ▼
- [ ] Manual: Type content inside toggle section, save, reopen → verify content persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the editor’s Details toggle: new toggle button with an arrow indicator that rotates on open, improved spacing, borders, padding, and typography, and refined summary and content styling for more consistent visuals and smoother interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->