### PR TITLE
Fix linked account item styling to match profile cards

### DIFF
--- a/src/PraxisNote.Web/ClientApp/src/app/settings/settings.page.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/settings/settings.page.ts
@@ -93,9 +93,9 @@ const MAX_PROFILES = 5;
           } @else {
             <div class="space-y-2 mb-4">
               @for (identity of linkedAccountsService.identities(); track identity.id) {
-                <div class="flex items-center gap-3 px-4 py-3 rounded-lg border border-border bg-surface">
+                <div class="flex items-center gap-3 px-4 py-3 rounded-lg border border-border bg-surface hover:bg-surface-muted/50 transition-colors">
                   <!-- Provider icon -->
-                  <div class="w-8 h-8 rounded-full bg-surface-muted flex items-center justify-center shrink-0">
+                  <div class="w-9 h-9 rounded-lg bg-surface-muted flex items-center justify-center shrink-0">
                     <i class="pi pi-google text-foreground-secondary text-sm" aria-hidden="true"></i>
                   </div>
 


### PR DESCRIPTION
## Summary
- Align linked account items with profile card styling by matching icon container size (`w-9 h-9` instead of `w-8 h-8`) and shape (`rounded-lg` instead of `rounded-full`)
- Add hover effect (`hover:bg-surface-muted/50 transition-colors`) to linked account items, matching the profile card pattern

Fixes #498

## Test plan
- [x] Angular build passes
- [x] All 778 unit tests pass
- [x] All 25 E2E tests pass
- [ ] Visual verification: linked account items align with profile cards in both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated the Linked Accounts list item styling in the settings page with hover background transition effects for improved interactivity.
  * Enhanced the provider avatar container appearance with increased size and rounded corners for better visual prominence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->