### PR TITLE
Fix tight spacing between cards on Settings page (#513)

### DIFF
--- a/src/PraxisNote.Web/ClientApp/src/app/settings/settings.page.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/settings/settings.page.ts
@@ -46,7 +46,7 @@ const MAX_PROFILES = 5;
               <span class="sr-only">Loading profiles...</span>
             </div>
           } @else {
-            <div class="space-y-2 mb-4">
+            <div class="space-y-3 mb-4">
               @for (profile of profileService.profiles(); track profile.id) {
                 <app-profile-card
                   [profile]="profile"
@@ -92,7 +92,7 @@ const MAX_PROFILES = 5;
               <span class="sr-only">Loading linked accounts...</span>
             </div>
           } @else {
-            <div class="space-y-2 mb-4">
+            <div class="space-y-3 mb-4">
               @for (identity of linkedAccountsService.identities(); track identity.id) {
                 <app-linked-account-card
                   [identity]="identity"


### PR DESCRIPTION
## Summary
- Increase vertical spacing between profile cards and linked account cards on the Settings page from `space-y-2` (8px) to `space-y-3` (12px) for comfortable visual breathing room

Closes #513

## Test plan
- [x] Unit tests pass (778 tests)
- [x] E2E tests pass (25 tests)
- [x] Code review: trivial CSS class change, no behavioral impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Adjust spacing between profile and linked account cards on the Settings page for improved visual layout.

Enhancements:
- Increase vertical spacing between profile cards on the Settings page for better readability and visual comfort.
- Increase vertical spacing between linked account cards on the Settings page to match the updated profile card layout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted vertical spacing in the Settings page for improved visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->