### PR TITLE
Fix PR screenshot uploads — use GitHub Releases for image hosting

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -130,25 +130,30 @@ Once tests pass and self-review fixes are committed:
    - Check responsive behavior if layout changes are involved
    - Test keyboard navigation if interactive elements are added
 6. **Upload screenshots to GitHub Releases**:
+   - Get the PR number and repo path programmatically:
+     ```bash
+     PR_NUM=$(gh pr view --json number -q '.number')
+     REPO_PATH=$(gh repo view --json nameWithOwner -q '.nameWithOwner')
+     ```
    - Ensure the `pr-screenshots` draft release exists:
      ```bash
      gh release view pr-screenshots 2>/dev/null || gh release create pr-screenshots --draft --title "PR Screenshots" --notes "Asset hosting for PR validation screenshots. Do not delete."
      ```
-   - Rename each screenshot to include the PR number prefix (avoids filename collisions across PRs):
+   - Copy screenshots to a temp directory with PR number prefix (avoids filename collisions across PRs):
      ```bash
-     # Example: for PR #507
+     UPLOAD_DIR=$(mktemp -d)
      for f in tests/PraxisNote.E2E.Tests/screenshots/<feature>/*.png; do
-       cp "$f" "tests/PraxisNote.E2E.Tests/screenshots/pr507-$(basename "$f")"
+       cp "$f" "$UPLOAD_DIR/pr${PR_NUM}-$(basename "$f")"
      done
      ```
    - Upload all prefixed screenshots to the release:
      ```bash
-     gh release upload pr-screenshots tests/PraxisNote.E2E.Tests/screenshots/pr507-*.png --clobber
+     gh release upload pr-screenshots "$UPLOAD_DIR"/pr${PR_NUM}-*.png --clobber
      ```
    - The `--clobber` flag overwrites if re-uploading after fixes.
 
 7. **Add screenshots to PR comment using release download URLs**:
-   - Construct URLs: `https://github.com/garethbaumgart/praxis-note/releases/download/pr-screenshots/<filename>.png`
+   - Construct URLs using the repo path: `https://github.com/${REPO_PATH}/releases/download/pr-screenshots/<filename>.png`
    - Use `gh pr comment` with these URLs in markdown `![Alt text](url)`
    - For refactoring: "No visual changes - before/after comparison attached"
    - For new features: "Feature working as expected - screenshots attached"
@@ -164,7 +169,10 @@ Once tests pass and self-review fixes are committed:
    ![Settings Dark](https://github.com/garethbaumgart/praxis-note/releases/download/pr-screenshots/pr507-04-settings-dark.png)
    ```
 
-8. **Clean up**: Delete any temporary validation scripts and local screenshot copies after they've been uploaded. The screenshots persist permanently on the GitHub Release.
+8. **Clean up**: Delete the temp upload directory, any temporary validation scripts, and local screenshot copies. The screenshots persist permanently on the GitHub Release.
+   ```bash
+   rm -rf "$UPLOAD_DIR"
+   ```
 9. **Fix any issues**: If something doesn't work or looks wrong, fix it, commit, push, and re-run tests
 
 **Screenshot requirements by PR type**:


### PR DESCRIPTION
## Summary

- Rewrites Step 7 sub-steps 6-7 of the `/pr` skill to upload screenshots to a dedicated `pr-screenshots` draft release via `gh release upload`, replacing fake placeholder URLs that never rendered on GitHub
- Screenshot filenames are namespaced by PR number (e.g., `pr507-01-settings-light.png`) to avoid collisions across PRs
- Uses permanent release download URLs (`https://github.com/.../releases/download/pr-screenshots/...`) that render correctly in PR comments

Closes #511

## Test plan

- [x] Verified the updated SKILL.md has correct sub-step numbering (6-9)
- [x] Verified the `pr-screenshots` draft release was created successfully
- [x] Confirmed no binary files are committed to the branch — screenshots are hosted externally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update the PR skill documentation to host validation screenshots via a shared GitHub Releases draft instead of inline uploads or placeholder URLs.

Enhancements:
- Document a standardized workflow for creating/ensuring a `pr-screenshots` draft release and uploading namespaced screenshots to it using `gh release`.
- Guide contributors to reference permanent GitHub Release download URLs in PR comments for UI validation screenshots, including an example comment format.
- Clarify cleanup steps to remove temporary scripts and local screenshot copies once uploads are complete.