### PR TITLE
Add scoped Boy Scout Rule to CLAUDE.md and PR skill

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -67,7 +67,7 @@ Review the full diff against the base branch using `git diff main...HEAD` and lo
 - Performance improvements without added complexity
 - Patterns that don't match existing codebase conventions
 - Missing null guards or error handling
-- **Boy Scout Rule**: Any banned patterns (`*ngIf`, `[ngClass]`, hardcoded colors, `dark:` prefix, constructor injection) in lines touched by this PR should be migrated to their modern equivalents
+- **Boy Scout Rule**: Any banned or discouraged patterns (`*ngIf`, `[ngClass]`, hardcoded colors, `dark:` prefix, constructor injection → `inject()`) in lines touched by this PR should be migrated to their modern equivalents
 
 ### Security
 - Missing `rel="noreferrer"` on external links (`target="_blank"`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ background: var(--color-todo-foreground);  /* This is a text color! */
 
 ### Boy Scout Rule (Scoped)
 
-When modifying code, fix banned patterns in the lines you're already changing — but do NOT expand scope.
+When modifying code, fix banned or discouraged patterns in the lines you're already changing — but do NOT expand scope.
 
 **DO fix (within lines you're already editing):**
 - `*ngIf` / `*ngFor` / `*ngSwitch` → `@if` / `@for` / `@switch` control flow


### PR DESCRIPTION
## Summary
- Add a "Boy Scout Rule (Scoped)" subsection under Critical Rules in CLAUDE.md that encourages fixing banned patterns within lines already being edited, without expanding scope beyond the current task
- Add a Boy Scout Rule check item to the PR skill's self-review Code Quality section
- CLAUDE.md stays at 620 lines (well under the 700-line limit)

Closes #519

## Test plan
- [x] CLAUDE.md contains "Boy Scout Rule (Scoped)" subsection under Critical Rules (after Component CSS Colors, before Pattern Examples)
- [x] PR skill includes Boy Scout check in self-review Code Quality section
- [x] CLAUDE.md line count verified at 620 lines (under 700 limit)
- [x] Build passes with zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Clarify and enforce a scoped "Boy Scout Rule" for incremental cleanup of banned patterns in modified lines, and surface this guideline in both contributor docs and the PR self-review checklist.

Documentation:
- Add a scoped "Boy Scout Rule" subsection to CLAUDE.md under Critical Rules to describe when and how to fix banned patterns while editing code.

Chores:
- Update the PR skill self-review checklist to include verifying Boy Scout Rule cleanup for banned patterns in touched lines.