### PR TITLE
Standardize GitHub Actions workflows to match flat-rate pattern

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'mockups/**'
+      - '.claude/**'
+
+jobs:
+  unit-tests:
+    uses: ./.github/workflows/unit-tests.yml
+    secrets: inherit
+
+  e2e-tests:
+    uses: ./.github/workflows/e2e-tests.yml
+    secrets: inherit

--- a/.github/workflows/deploy-cloud-run.yml
+++ b/.github/workflows/deploy-cloud-run.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   unit-tests:
-    uses: ./.github/workflows/tests.yml
+    uses: ./.github/workflows/unit-tests.yml
     secrets: inherit
 
   e2e-tests:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,16 +1,7 @@
 name: E2E Tests
 
 on:
-  push:
-    branches: [main]
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'mockups/**'
-      - '.claude/**'
-  pull_request:
-    branches: [main]
-  workflow_call: # Allow other workflows to call this one
+  workflow_call:
 
 jobs:
   e2e-tests:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,16 +1,7 @@
 name: Unit Tests
 
 on:
-  push:
-    branches: [main]
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'mockups/**'
-      - '.claude/**'
-  pull_request:
-    branches: [main]
-  workflow_call: # Allow other workflows to call this one
+  workflow_call:
 
 jobs:
   unit-tests:


### PR DESCRIPTION
## Summary

- Rename `tests.yml` to `unit-tests.yml` for clarity
- Remove `push` and `pull_request` triggers from `unit-tests.yml` and `e2e-tests.yml`, keeping only `workflow_call`
- Create new `ci.yml` that triggers on `pull_request` to main and calls both test workflows
- Update `deploy-cloud-run.yml` to reference `unit-tests.yml`

This eliminates duplicate workflow runs on merged PRs by cleanly separating PR validation (`ci.yml`) from deployment (`deploy-cloud-run.yml`).

Closes #527

## Test plan

- [x] Unit tests pass locally
- [x] E2E tests pass locally (25/25)
- [x] Verified `unit-tests.yml` has only `workflow_call` trigger
- [x] Verified `e2e-tests.yml` has only `workflow_call` trigger
- [x] Verified `ci.yml` triggers on `pull_request` with correct `paths-ignore`
- [x] Verified `deploy-cloud-run.yml` references `unit-tests.yml` (not `tests.yml`)
- [x] No UI changes — browser validation skipped

> **CI Note**: Since this PR changes the workflow files themselves, CI will use the OLD workflow configuration (from `main`) for the PR checks. The new `ci.yml` won't be active until merged. The existing `tests.yml` and `e2e-tests.yml` will still trigger on the PR via their current `pull_request` triggers. This is expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Standardize GitHub Actions CI workflows by centralizing pull request validation and making test workflows reusable.

CI:
- Limit unit and E2E test workflows to be triggered only via workflow_call for reuse.
- Introduce a new CI workflow that runs unit and E2E tests on pull requests to main with shared path-ignore settings.
- Update the Cloud Run deployment workflow to invoke the renamed unit test workflow before deployment.