### PR TITLE
Optimise GitHub Actions minutes for private repo transition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
       - 'mockups/**'
       - '.claude/**'
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unit-tests:
     uses: ./.github/workflows/unit-tests.yml

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,6 +15,14 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-
+
       - name: Restore dependencies
         run: dotnet restore src/PraxisNote.slnx
 


### PR DESCRIPTION
## Summary

- Add concurrency group to `ci.yml` to cancel in-progress CI runs when a new commit is pushed to the same branch, avoiding wasted minutes on stale builds
- Add NuGet package caching to `unit-tests.yml` (matching the existing pattern in `e2e-tests.yml`) to speed up dependency restore

Closes #532

## Test plan

- [x] `dotnet build` passes
- [x] `dotnet test` passes
- [x] ci.yml has concurrency group between `on:` and `jobs:` blocks
- [x] unit-tests.yml has NuGet cache step before `Restore dependencies`
- [x] Cache key pattern matches e2e-tests.yml (`nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj') }}`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Optimize GitHub Actions workflows to reduce wasted CI minutes and speed up .NET test runs.

CI:
- Add a concurrency group to the main CI workflow to cancel in-progress runs when new commits are pushed to the same branch.
- Introduce NuGet package caching in the unit test workflow to reuse restored dependencies across runs.