### PR TITLE
Add atomic commit guidelines to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -609,6 +609,26 @@ git checkout -b chore/update-dependencies
 - `chore/` - Maintenance tasks, refactoring, dependencies
 - `docs/` - Documentation only changes
 
+### Atomic Commits
+
+Keep commits atomic: commit only the files you touched and list each path explicitly.
+
+**For tracked (modified) files:**
+```bash
+git commit -m "<scoped message>" -- path/to/file1 path/to/file2
+```
+
+**For brand-new (untracked) files:**
+```bash
+git restore --staged :/ && git add "path/to/file1" "path/to/file2" && git commit -m "<scoped message>" -- path/to/file1 path/to/file2
+```
+
+**Rules:**
+- **NEVER** use `git add .` or `git add -A` — these can stage unrelated files
+- Always list files explicitly by path
+- Each commit should contain only related changes (one logical unit of work)
+- Use `git restore --staged :/` before adding new files to ensure a clean staging area
+
 ### PR Workflow
 
 **ALWAYS** use the `/pr` skill when creating or updating a pull request. This ensures README is reviewed, tests are run, the PR is properly reviewed, and CI checks are monitored for warnings.


### PR DESCRIPTION
## Summary
- Adds a new `### Atomic Commits` subsection to the Git Workflow section of CLAUDE.md
- Documents explicit file-path commit patterns for both tracked and untracked files
- Bans `git add .` and `git add -A` to prevent accidental staging of unrelated files

Closes #534

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Add an 'Atomic Commits' subsection to CLAUDE.md describing explicit path-based committing for tracked and untracked files, banning blanket staging commands like `git add .` and `git add -A`.