### PR TITLE
Fix Google OAuth 500 on login

### DIFF
--- a/src/PraxisNote.Web/Program.cs
+++ b/src/PraxisNote.Web/Program.cs
@@ -124,11 +124,42 @@ if (!string.IsNullOrEmpty(clientId) && !string.IsNullOrEmpty(clientSecret))
         // Map the picture claim from Google's user info response
         options.ClaimActions.MapJsonKey("picture", "picture");
 
+        // Configure correlation cookie for Firebase Hosting proxy compatibility.
+        // SameSite=None is required because the OAuth callback crosses through the
+        // Firebase proxy, which is treated as a cross-site context by the browser.
+        // Local dev uses mock auth (not Google), so this doesn't affect development.
+        options.CorrelationCookie.SameSite = SameSiteMode.None;
+        options.CorrelationCookie.SecurePolicy = CookieSecurePolicy.Always;
+
         // Force account selection on each login (useful after logout)
         options.Events.OnRedirectToAuthorizationEndpoint = context =>
         {
             var uri = QueryHelpers.AddQueryString(context.RedirectUri, "prompt", "select_account");
             context.Response.Redirect(uri);
+            return Task.CompletedTask;
+        };
+
+        // Handle remote authentication failures gracefully instead of returning 500.
+        // Distinguishes user cancellation (access_denied) from real errors.
+        options.Events.OnRemoteFailure = context =>
+        {
+            var logger = context.HttpContext.RequestServices.GetRequiredService<ILoggerFactory>()
+                .CreateLogger("GoogleAuth");
+
+            var errorCode = context.HttpContext.Request.Query["error"].FirstOrDefault();
+            if (string.Equals(errorCode, "access_denied", StringComparison.OrdinalIgnoreCase))
+            {
+                // User cancelled the login — redirect home silently
+                logger.LogInformation("User cancelled Google login");
+                context.Response.Redirect("/");
+            }
+            else
+            {
+                logger.LogWarning(context.Failure, "Google OAuth remote failure: {Message}", context.Failure?.Message);
+                context.Response.Redirect("/?error=auth_failed");
+            }
+
+            context.HandleResponse();
             return Task.CompletedTask;
         };
     });


### PR DESCRIPTION
## Summary
- Fix 500 error when logging in with Google on praxisnote.app
- Root cause: Firebase Hosting proxy drops the OAuth correlation cookie when forwarding to Cloud Run, causing `AuthenticationFailureException: Correlation failed`
- Set `SameSite=None` on the correlation cookie for cross-site proxy compatibility
- Add `OnRemoteFailure` handler to gracefully redirect to `/?error=auth_failed` instead of returning a raw 500

## Test plan
- [x] Unit tests pass (536 domain + 7 integration)
- [x] Project builds successfully
- [ ] Deploy to Cloud Run and verify Google OAuth login works on praxisnote.app
- [ ] Verify correlation cookie is set with `SameSite=None; Secure` in browser dev tools
- [ ] Verify failed auth redirects to `/?error=auth_failed` instead of 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Handle Google OAuth correlation failures more gracefully in the web app.

Bug Fixes:
- Prevent Google OAuth login from returning a 500 error when the correlation cookie is dropped by the hosting proxy.

Enhancements:
- Configure the Google OAuth correlation cookie with SameSite=None and Secure to support cross-site proxy scenarios.
- Add a remote failure handler for Google OAuth that logs the error and redirects users to a friendly error page instead of failing the request.