### PR TITLE
Fix slash command menu transparent background (#574)

### DIFF
--- a/src/PraxisNote.Web/ClientApp/src/app/notes/note-card.component.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/notes/note-card.component.ts
@@ -329,7 +329,7 @@ import { DeleteConfirmButtonComponent } from '../shared/components/delete-confir
     }
 
     :host ::ng-deep .note-preview code {
-      background: var(--color-surface-default);
+      background: var(--color-surface-muted);
       padding: 0.1em 0.3em;
       border-radius: 3px;
       font-family: monospace;
@@ -386,7 +386,7 @@ import { DeleteConfirmButtonComponent } from '../shared/components/delete-confir
     }
 
     :host ::ng-deep .note-preview th {
-      background: var(--color-surface-hover);
+      background: var(--color-surface-muted);
       font-weight: 600;
     }
 

--- a/src/PraxisNote.Web/ClientApp/src/app/notes/slash-command-menu.component.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/notes/slash-command-menu.component.ts
@@ -63,7 +63,7 @@ import { SlashCommandItem } from './extensions/slash-command-items';
         width: 280px;
         max-height: 320px;
         overflow-y: auto;
-        background: var(--color-surface-default);
+        background: var(--color-surface-subtle);
         border: 1px solid var(--color-border);
         border-radius: 8px;
         box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
@@ -97,14 +97,14 @@ import { SlashCommandItem } from './extensions/slash-command-items';
         background: transparent;
         cursor: pointer;
         font-size: 13px;
-        color: var(--color-foreground-default);
+        color: var(--color-foreground);
         text-align: left;
         transition: background 0.1s;
       }
 
       .slash-menu-item:hover,
       .slash-menu-item-active {
-        background: var(--color-surface-hover);
+        background: var(--color-surface-muted);
       }
 
       .slash-menu-item-icon {
@@ -123,7 +123,7 @@ import { SlashCommandItem } from './extensions/slash-command-items';
         font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
         font-size: 10px;
         color: var(--color-foreground-muted);
-        background: var(--color-surface-hover);
+        background: var(--color-surface-muted);
         padding: 1px 5px;
         border-radius: 3px;
         margin-left: 4px;

--- a/src/PraxisNote.Web/ClientApp/src/app/notes/tiptap-editor.component.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/notes/tiptap-editor.component.ts
@@ -387,7 +387,7 @@ interface BlockType {
       content: ''; position: absolute; top: 50%; left: 50%;
       transform: translate(-50%,-50%); width: 44px; height: 44px;
     }
-    .toolbar-btn:hover { background: var(--color-surface-hover); color: var(--color-foreground-default); }
+    .toolbar-btn:hover { background: var(--color-surface-muted); color: var(--color-foreground); }
     .toolbar-btn.active { background: var(--color-accent-subtle); color: var(--color-accent-solid); }
     .toolbar-btn.task-list-btn.active { background: var(--color-accent-solid); color: white; }
     .toolbar-btn.color-btn { flex-direction: column; gap: 1px; font-weight: 600; font-size: 12px; }
@@ -528,7 +528,7 @@ interface BlockType {
     }
 
     :host ::ng-deep .ProseMirror code {
-      background: var(--color-surface-default);
+      background: var(--color-surface-muted);
       padding: 0.2em 0.4em;
       border-radius: 4px;
       font-family: monospace;
@@ -537,7 +537,7 @@ interface BlockType {
 
     :host ::ng-deep .ProseMirror pre {
       background: var(--color-surface-muted);
-      color: var(--color-foreground-default);
+      color: var(--color-foreground);
       padding: 0.75em 1em;
       border-radius: 6px;
       overflow-x: auto;
@@ -599,7 +599,7 @@ interface BlockType {
     }
 
     :host ::ng-deep .ProseMirror th {
-      background: var(--color-surface-hover);
+      background: var(--color-surface-muted);
       font-weight: 600;
     }
 


### PR DESCRIPTION
## Summary
- Replace 3 non-existent CSS variable names (`--color-surface-default`, `--color-foreground-default`, `--color-surface-hover`) with correct theme tokens across `slash-command-menu.component.ts`, `tiptap-editor.component.ts`, and `note-card.component.ts`
- Fixes the slash command menu having a transparent background that lets editor text bleed through
- Also fixes invisible toolbar hover states, inline code backgrounds, code block text colors, and table header backgrounds in the note editor and note cards

## Changes
| File | Replacements |
|------|-------------|
| `slash-command-menu.component.ts` | Menu bg: `--color-surface-subtle`; text: `--color-foreground`; hover/alias bg: `--color-surface-muted` |
| `tiptap-editor.component.ts` | Toolbar hover: `--color-surface-muted` + `--color-foreground`; inline code bg: `--color-surface-muted`; code block text: `--color-foreground`; table header bg: `--color-surface-muted` |
| `note-card.component.ts` | Inline code bg: `--color-surface-muted`; table header bg: `--color-surface-muted` |

## Test plan
- [x] Angular build passes (`ng build`)
- [x] All .NET unit tests pass (536 Domain + 256 Application + 7 Integration)
- [x] All frontend unit tests pass (186 tests)
- [x] No remaining invalid CSS variable references in notes feature files
- [x] Visual: Slash command menu has solid background in both light and dark mode
- [x] Visual: Toolbar buttons show hover state
- [x] Visual: Inline code and table headers have visible backgrounds

Closes #574

🤖 Generated with [Claude Code](https://claude.com/claude-code)