### PR TITLE
Fix task card due date expanded section overflow (#578)

### DIFF
--- a/src/PraxisNote.Web/ClientApp/src/app/tasks/task-card.component.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/tasks/task-card.component.ts
@@ -212,7 +212,7 @@ import { TaskCommentsSectionComponent } from './task-comments-section.component'
         }
 
         <!-- Tab bar - Google Home style -->
-        <div class="mt-2 flex items-center gap-1.5 relative">
+        <div class="mt-2 flex flex-wrap items-center gap-1.5 relative">
           <!-- Due Date tab -->
           <app-task-due-date-section
             [dueDate]="task().dueDate"

--- a/src/PraxisNote.Web/ClientApp/src/app/tasks/task-due-date-section.component.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/tasks/task-due-date-section.component.ts
@@ -6,6 +6,7 @@ import { DatePickerPopoverComponent } from './date-picker-popover.component';
   selector: 'app-task-due-date-section',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
+  host: { style: 'display: contents' },
   imports: [DatePickerPopoverComponent],
   template: `
     <!-- Due Date tab button -->
@@ -46,7 +47,7 @@ import { DatePickerPopoverComponent } from './date-picker-popover.component';
 
     <!-- Due Date expanded content -->
     @if (expanded()) {
-      <div class="mt-2 p-2 bg-duedate-section rounded-lg border border-duedate-section-border relative">
+      <div class="w-full order-last mt-2 p-2 bg-duedate-section rounded-lg border border-duedate-section-border relative">
         <div class="flex items-center gap-1 flex-wrap">
           <button
             type="button"


### PR DESCRIPTION
## Summary
- Adds `flex-wrap` to the tab bar row so the expanded due date panel can wrap to a new line
- Sets `display: contents` on the due date section host element so its children participate directly in the parent flex layout
- Adds `w-full order-last` to the expanded panel div so it takes full width on its own row below the tab buttons

Fixes #578

## Test plan
- [x] Angular build passes with no new errors
- [x] All 799 .NET unit tests pass
- [x] All 25 E2E tests pass
- [x] Browser validation: expanded due date section renders below tab bar, source pill stays inside card

🤖 Generated with [Claude Code](https://claude.com/claude-code)