### PR TITLE
Add E2E test for inline date node slash command (#561)

### DIFF
--- a/tests/PraxisNote.E2E.Tests/smoke-tests/notes.spec.ts
+++ b/tests/PraxisNote.E2E.Tests/smoke-tests/notes.spec.ts
@@ -183,10 +183,13 @@ test.describe('Notes', () => {
     await expect(popover.getByText('Tomorrow')).toBeVisible();
     await expect(popover.getByText('Next Mon')).toBeVisible();
 
-    // Click "Tomorrow" quick-pick and verify popover closes
+    // Click "Tomorrow" quick-pick and verify popover closes and date changes
     await popover.getByText('Tomorrow').click();
     await expect(popover).not.toBeVisible();
     await expect(dateChip).toBeVisible();
+    const updatedChipText = await dateChip.textContent();
+    expect(updatedChipText).toBeTruthy();
+    expect(updatedChipText).not.toBe(chipText);
 
     // Reopen and dismiss by clicking outside (Escape may be captured by native date input)
     await dateChip.click();


### PR DESCRIPTION
## Summary
- Adds an E2E test to `notes.spec.ts` that verifies the inline date node feature end-to-end
- Tests inserting a date via the `/date` slash command, verifying the date chip renders with formatted text
- Tests the popover interaction: opening, verifying quick-pick buttons (Today/Tomorrow/Next Mon), selecting "Tomorrow", and dismissing via click-outside

Closes #561

## Test plan
- [x] Unit tests pass (`dotnet test` - 799 tests)
- [x] E2E tests pass (26/26 including the new test)
- [x] New test exercises slash command menu, date chip rendering, popover open/close, and quick-pick selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end test coverage for date insertion and management in notes, including popover interactions and state updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->