### PR TITLE
Fix date node calendar picker closing on click (#585)

### DIFF
--- a/src/PraxisNote.Web/ClientApp/src/app/notes/extensions/insert-date.extension.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/notes/extensions/insert-date.extension.ts
@@ -173,6 +173,7 @@ export const DateNode = Node.create({
       }
 
       function onWrapperActivate(e: Event) {
+        if (popover && popover.contains(e.target as HTMLElement)) return;
         e.stopPropagation();
         e.preventDefault();
         openPopover();

--- a/src/PraxisNote.Web/ClientApp/src/app/notes/tiptap-editor.spec.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/notes/tiptap-editor.spec.ts
@@ -427,6 +427,27 @@ describe('TipTap Editor', () => {
       }
     });
 
+    it('clicking inside date popover does not close it', () => {
+      editor.commands.insertDate();
+      const dom = editor.view.dom;
+      const chip = dom.querySelector('span[data-type="dateNode"]') as HTMLElement;
+      expect(chip).toBeTruthy();
+
+      // Open the popover
+      chip.click();
+      const popover = dom.querySelector('.date-node-popover') as HTMLElement;
+      expect(popover).toBeTruthy();
+
+      // Click inside the popover (on the date input)
+      const dateInput = popover.querySelector('.date-node-picker-input') as HTMLElement;
+      expect(dateInput).toBeTruthy();
+      dateInput.click();
+
+      // Popover should still be visible
+      const stillOpen = dom.querySelector('.date-node-popover');
+      expect(stillOpen).toBeTruthy();
+    });
+
     it('insertDate with explicit date stores that date', () => {
       editor.commands.insertDate('2026-12-25');
 


### PR DESCRIPTION
## Summary
- Fixes the date node popover closing when clicking the native date input's calendar icon
- Root cause: the wrapper's `click` handler called `preventDefault()` and toggled the popover closed on every click, including clicks inside the popover itself
- Fix: adds an early-return guard in `onWrapperActivate` so clicks inside the popover are ignored by the wrapper handler

Closes #585

## Test plan
- [x] Unit test added: clicking inside the date popover does not close it
- [x] All 187 frontend unit tests pass
- [x] All 799 backend unit tests pass
- [x] Quick-pick buttons still work (guard only applies when popover exists and click is inside it)
- [x] Clicking outside the popover still dismisses it (document click handler unchanged)
- [x] Escape key still dismisses the popover (keydown handler unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where clicking or interacting inside the date popover would cause it to unexpectedly reopen or retrigger. Users can now seamlessly interact with date selection fields within the popover without any disruption.

* **Tests**
  * Added test coverage to verify that the date popover remains stable and open when users interact within it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->