### PR TITLE
Fix MCP endpoint hijacking root route and blocking deploys

### DIFF
--- a/src/PraxisNote.Web/Program.cs
+++ b/src/PraxisNote.Web/Program.cs
@@ -342,7 +342,7 @@ app.MapTranscriptionEndpoints();
 app.MapApiKeyEndpoints();
 
 // MCP endpoint for OpenClaw and other MCP clients
-app.MapMcp().RequireAuthorization().RequireRateLimiting("mcp");
+app.MapMcp("/mcp").RequireAuthorization().RequireRateLimiting("mcp");
 
 // SPA fallback - serves index.html for client-side routing
 if (angularAppExists)


### PR DESCRIPTION
## Summary
- `MapMcp()` without a path prefix registered MCP endpoints at `/`, intercepting `GET /` before the Angular SPA fallback could serve `index.html`
- This caused all 3 features merged since the MCP server PR (#588, #589, #590) to fail E2E tests and skip deployment
- Fix: `MapMcp("/mcp")` — scopes MCP to the `/mcp` prefix, consistent with existing `ForwardDefaultSelector` and `ProfileValidationMiddleware` which already check for `/mcp`

## Root Cause
ASP.NET Core endpoint routing gives specific routes (`GET /` from MCP) priority over fallbacks (`MapFallbackToFile`). The MCP endpoint returned 401 (auth required) for unauthenticated `GET /` requests instead of serving the SPA.

## Test plan
- [x] Unit tests pass (882 tests)
- [x] `GET /` returns SPA HTML (verified with curl)
- [x] `GET /mcp` returns 401 (MCP auth required)
- [ ] E2E tests pass in CI
- [ ] Deploy succeeds, unblocking features from #588, #589, #590

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated MCP API endpoint routing configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->