### PR TITLE
Document fetch() vs HttpClient rule to prevent auth interceptor bugs

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -79,6 +79,7 @@ Review the full diff against the base branch using `git diff main...HEAD` and lo
 - Timezone-safe date handling (use `new Date(year, month - 1, day)` for date-only strings, not `new Date(dateString)` which applies timezone offsets)
 - Invalid date guards (check `isNaN(d.getTime())` before using parsed dates)
 - Accessibility issues (missing `aria-label` on icon-only buttons, semantic HTML)
+- **Auth interceptor interaction**: Any new `HttpClient` call will go through the auth interceptor, which forces a full page reload on 401. If the call is non-critical (starters, suggestions, background data), use `fetch()` instead. See CLAUDE.md "Auth Interceptor" section.
 
 ### Backend
 - EF Core: JSON value conversion properties (e.g., `HashSet<Guid>`) cannot use `.Contains()` in LINQ-to-SQL — must filter in memory

--- a/.claude/skills/refine/SKILL.md
+++ b/.claude/skills/refine/SKILL.md
@@ -280,6 +280,7 @@ Append this machine-readable checklist to the end of every refined issue body. E
 - [ ] Verification steps defined for each acceptance criterion
 - [ ] Optimistic update impact assessed
 - [ ] E2E test decision documented (add/skip with reason)
+- [ ] New API calls use correct HTTP client (`HttpClient` for critical CRUD, `fetch()` for non-critical — see CLAUDE.md "Auth Interceptor")
 ```
 
 If a checklist item does not apply (e.g., "Template HTML" for a backend-only change), check it and add "N/A — backend only".
@@ -443,6 +444,7 @@ gh issue edit <number> --body "$(cat <<'ISSUE_BODY'
 - [ ] Verification steps defined for each acceptance criterion
 - [ ] Optimistic update impact assessed
 - [ ] E2E test decision documented (add/skip with reason)
+- [ ] New API calls use correct HTTP client (`HttpClient` for critical CRUD, `fetch()` for non-critical — see CLAUDE.md "Auth Interceptor")
 ISSUE_BODY
 )"
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,32 @@ These rules cause the most common sub-agent mistakes. They are listed first for 
 [class.active]="isActive()"
 ```
 
+### Auth Interceptor — `fetch()` vs `HttpClient`
+
+The auth interceptor (`auth.interceptor.ts`) catches **any 401 response** from `HttpClient` calls and forces a full page reload (`window.location.href = '/'`). This is by design for session expiry — but it means **non-critical API calls that use `HttpClient` can crash the entire page if auth fails unexpectedly.**
+
+```typescript
+// WRONG: Non-critical call uses HttpClient — 401 causes page refresh
+this.http.post('/api/tags/123/starters', {}).subscribe({ ... });
+
+// CORRECT: Non-critical call uses fetch() — 401 is handled gracefully
+const response = await fetch('/api/tags/123/starters', {
+  method: 'POST',
+  headers,
+  credentials: 'include',
+  body: '{}',
+});
+```
+
+**Rule:** Use `fetch()` (not `HttpClient`) for API calls where a failure should NOT trigger a page-level auth redirect. This includes:
+- AI chat starters, suggestions, and other "nice to have" data
+- Background/fire-and-forget calls
+- SSE streaming endpoints (already required for technical reasons)
+
+Use `HttpClient` for calls where a 401 genuinely means "user needs to re-authenticate" (core CRUD operations like loading tasks, notes, meetings).
+
+When using `fetch()`, you must manually add auth headers (mock auth in dev mode, profile ID). Follow the pattern in `tag-ai-chat.service.ts:send()`.
+
 ### Zoneless Anti-Patterns
 
 Angular 21 is zoneless by default. These patterns **will NOT work**:


### PR DESCRIPTION
## Summary
- Add "Auth Interceptor" section to CLAUDE.md Critical Rules explaining when to use `fetch()` vs `HttpClient`
- Add frontend self-review check to `/pr` skill for auth interceptor interactions
- Add pre-flight checklist item to `/refine` skill for HTTP client selection

## Context
The Ask AI page refresh bug (#592) was caused by a gap in our workflow — the refine plan didn't specify which HTTP client to use, the self-review didn't check for interceptor interactions, and E2E tests can't reproduce production auth. These docs changes close the gap at the planning and review stages.

## Test plan
- [x] Markdown-only changes — no runtime impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)