### PR TITLE
Show meeting badge before title on note cards

### DIFF
--- a/src/PraxisNote.Web/ClientApp/src/app/notes/note-card.component.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/notes/note-card.component.ts
@@ -22,17 +22,17 @@ import { DeleteConfirmButtonComponent } from '../shared/components/delete-confir
       (keydown.space)="handleCardKeydown(asKeyboardEvent($event))"
     >
       <div class="p-3">
-        <!-- Title (extracted from first heading) -->
-        @if (cardTitle()) {
-          <h3 class="card-title">{{ cardTitle() }}</h3>
-        }
-
-        <!-- Meeting badge -->
+        <!-- Meeting badge (shown first for meeting-linked notes) -->
         @if (note().meetingId) {
           <span class="inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 bg-surface-muted rounded text-foreground-muted mb-1">
             <i class="pi pi-video text-[9px]"></i>
             {{ note().meetingTitle ?? 'Meeting' }}
           </span>
+        }
+
+        <!-- Title (extracted from first heading) -->
+        @if (cardTitle()) {
+          <h3 class="card-title">{{ cardTitle() }}</h3>
         }
 
         <!-- Rich content preview -->


### PR DESCRIPTION
## Summary
- Reorders the note card template in `note-card.component.ts` so the meeting indicator badge renders **before** the title heading
- Meeting-linked notes now show the meeting badge as the first line on the notes home page, making them easier to identify at a glance
- No changes to logic, styles, backend, or other components -- purely a template element reorder

Closes #621

## Test plan
- [ ] Navigate to Notes page with meeting-linked notes and verify the meeting badge appears above the title
- [ ] Verify standalone (non-meeting) notes still show title as the first element
- [ ] Verify notes with a meeting badge but no title still render correctly
- [ ] Check responsive layout on mobile and desktop

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reordered elements in the note card display to show meeting information before the title for improved visual arrangement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->