### PR TITLE
Fix promote-to-task in meeting notes editor (#620)

### DIFF
--- a/src/PraxisNote.Web/ClientApp/src/app/meetings/meeting-editor.page.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/meetings/meeting-editor.page.ts
@@ -777,6 +777,8 @@ export class MeetingEditorPage implements OnInit, AfterViewInit, OnDestroy {
           this.meetingNoteLoading.set(false);
           if (content) {
             this.loadMeetingNoteCheckboxStatuses(meeting.noteId!);
+          } else {
+            this.meetingNoteCheckboxStatuses.set([]);
           }
         } else if (noteLoadAttempts >= 200) {
           // Timeout after ~10s
@@ -831,6 +833,7 @@ export class MeetingEditorPage implements OnInit, AfterViewInit, OnDestroy {
   onNotePromoteCheckbox(event: { checkboxIndex: number }): void {
     const meeting = this.currentMeeting();
     const noteId = meeting?.noteId;
+    const capturedMeetingId = this.meetingId();
     if (!noteId) {
       this.toast.error('Save the note first before promoting checkboxes');
       return;
@@ -838,21 +841,32 @@ export class MeetingEditorPage implements OnInit, AfterViewInit, OnDestroy {
 
     const checkboxId = `cb-${event.checkboxIndex + 1}`;
 
-    this.noteService.promoteCheckbox(noteId, checkboxId).subscribe({
-      next: (result) => {
-        this.toast.success({ summary: 'Task created', detail: result.title });
-        this.loadMeetingNoteCheckboxStatuses(noteId);
-      },
-      error: () => {
-        this.toast.error('Failed to promote checkbox to task');
-      },
-    });
+    this.noteService.promoteCheckbox(noteId, checkboxId)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (result) => {
+          if (this.meetingId() !== capturedMeetingId) return;
+          this.toast.success({ summary: 'Task created', detail: result.title });
+          this.loadMeetingNoteCheckboxStatuses(noteId);
+        },
+        error: () => {
+          if (this.isDestroyed) return;
+          this.toast.error('Failed to promote checkbox to task');
+        },
+      });
   }
 
   private loadMeetingNoteCheckboxStatuses(noteId: string): void {
+    const capturedMeetingId = this.meetingId();
     this.noteService.getCheckboxStatus(noteId).subscribe({
-      next: (statuses) => this.meetingNoteCheckboxStatuses.set(statuses),
-      error: () => this.meetingNoteCheckboxStatuses.set([]),
+      next: (statuses) => {
+        if (this.meetingId() !== capturedMeetingId) return;
+        this.meetingNoteCheckboxStatuses.set(statuses);
+      },
+      error: () => {
+        if (this.meetingId() !== capturedMeetingId) return;
+        this.meetingNoteCheckboxStatuses.set([]);
+      },
     });
   }
 


### PR DESCRIPTION
## Summary
- Wire up the missing `[checkboxStatuses]` input and `(promoteCheckbox)` output on the TipTap editor embedded in the meeting editor page
- Inject `NoteService` to reuse existing `promoteCheckbox()` and `getCheckboxStatus()` APIs -- no backend changes needed
- Load checkbox statuses when meeting note content loads; refresh after each successful promotion

Closes #620

## Test plan
- [x] Angular build succeeds (`ng build`)
- [x] .NET build succeeds (`dotnet build`)
- [x] All unit tests pass (597 domain + 291 application + 7 integration = 895 total)
- [ ] Promote button works: Open a meeting with notes containing checkboxes, hover, click promote -- toast confirms "Task created" and checkbox shows status badge
- [ ] Status badges display: Open meeting where checkbox was previously promoted -- checkbox shows task status badge instead of promote button
- [ ] Unsaved note guard: Create new meeting, add checkboxes before note is saved, click promote -- error toast appears
- [ ] Standalone notes unaffected: Promoting from standalone notes still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Convert meeting note checkboxes into actionable tasks directly from the note editor
* Checkbox statuses now tracked and displayed in the meeting editor for better visibility and task management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->