### PR TITLE
Fix: enforce pre-merge checklist and review comment acknowledgment

### DIFF
--- a/.claude/skills/execute-issues/SKILL.md
+++ b/.claude/skills/execute-issues/SKILL.md
@@ -106,16 +106,22 @@ The prompt to the sub-agent MUST include ALL of the following context so it can 
 >
 > 5. **Create PR and Merge**: Run the /pr skill to create a PR, run tests, monitor CI, address review comments, and merge. Override these /pr steps:
 >    - /pr Step 3 (Broadcast): EITHER "Run /broadcast automatically (no user prompt) — this is a user-facing change." OR "Skip broadcast — this is a minor/internal change."
->    - /pr Step 10 (Merge Approval): Merge immediately without waiting for user approval. Do NOT ask the user.
+>    - /pr Step 11 (Merge Approval): Merge immediately without waiting for user approval. Do NOT ask the user. Note: Step 10 (Pre-Merge Verification) is NON-SKIPPABLE — all PR checkboxes, acceptance criteria, and review comment acknowledgments must be verified before merge regardless of autonomous mode.
 >
-> 6. **Verify and Clean Up**: After merge, confirm the PR state with `gh pr view --json state,number,url`. Then clean up the worktree:
+> 6. **Pre-Merge Verification** (after /pr completes CI and reviews but before merge is final):
+>    - Verify ALL checkboxes in the PR body are checked (`[x]`) — test plan items and any other checklists
+>    - Verify ALL acceptance criteria on the linked GitHub issue are checked off
+>    - Verify ALL review comments (CodeRabbit, Copilot, any reviewer) have been acknowledged with a 👍 reaction or a reply
+>    - If any of these are incomplete, address them before the merge proceeds. This is a hard gate — do not merge with unchecked boxes or unacknowledged comments.
+>
+> 7. **Verify and Clean Up**: After merge, confirm the PR state with `gh pr view --json state,number,url`. Then clean up the worktree:
 >    ```bash
 >    cd MAIN_REPO_DIR
 >    git worktree remove ../praxis-note-issue-NUMBER
 >    git pull
 >    ```
 >
-> 7. **Report Back**: When done, report a single summary line with: issue number, PR number, PR URL, and status (Merged/Failed). If you created a broadcast notification, mention that too.
+> 8. **Report Back**: When done, report a single summary line with: issue number, PR number, PR URL, and status (Merged/Failed). If you created a broadcast notification, mention that too.
 >
 > **Critical Rules:**
 > - Do NOT ask the user any questions. Work fully autonomously.

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -217,9 +217,13 @@ After the PR is created, **actively monitor** and address feedback:
    - Keep checking every 5 minutes until BOTH CodeRabbit AND Copilot reviews are complete
 4. **Address all comments immediately**: When comments appear:
    - Read each comment carefully, including **high-level feedback** in comment bodies (not just line-specific suggestions)
-   - **For line comments (have their own ID)**:
-     - **If addressing**: Add a thumbs up reaction using `gh api repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions -X POST -f content='+1'`, then make the fix
-     - **If not addressing**: Reply to the comment explaining why (must be a strong justification - see below)
+
+   **IMPORTANT — Acknowledge Every Comment**:
+   Every line-level review comment MUST receive one of:
+   - A 👍 reaction (if addressing the suggestion) via `gh api repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions -X POST -f content='+1'`
+   - A reply explaining why the suggestion was not adopted (if not addressing it)
+   No comment should be left without acknowledgment. This is verified in Step 10.
+
    - **For high-level feedback in PR comments**: Reply to the comment addressing each suggestion
 
    **IMPORTANT - Batch Review Fixes**:
@@ -250,14 +254,23 @@ After the PR is created, **actively monitor** and address feedback:
 
 **Do not stop monitoring until**: CI is green, all line-level comments have been fetched and addressed, and either (a) all AI reviewers have reviewed the latest commit SHA, or (b) the 10-minute polling timeout has elapsed for reviewers whose previous round had no unaddressed comments.
 
-## Step 10: User Approval and Merge
+## Step 10: Pre-Merge Verification (Non-Skippable)
+
+**This step cannot be overridden or skipped — even when merging autonomously.**
 
 Once CI is green and all comments are addressed:
 
-1. **Verify test plan completion**: Before requesting merge approval, verify that ALL test plan checkboxes in the PR description are checked. If any manual verification items remain unchecked, complete them first or convert them to automated checks. Do not proceed until every checkbox is marked done.
-2. **Notify the user**: Tell them the PR is ready for their review and approval
-3. **Wait for approval**: Do NOT merge until the user explicitly approves
-4. **If feedback given**: Make fixes, commit, push, and repeat from Step 4 (build, tests + browser validation)
-5. **If approved**: Proceed to merge with `gh pr merge --squash --delete-branch`
+1. **Verify test plan completion**: Verify that ALL test plan checkboxes in the PR description are checked (`[x]`). If any remain unchecked, complete the verification and check them off — or fix the implementation if the check fails. Do not proceed until every checkbox is marked done.
+2. **Verify acceptance criteria**: If this PR references a GitHub issue, verify ALL acceptance criteria checkboxes on the issue are checked (`[x]`). If any remain unchecked, go back to Step 8.
+3. **Verify all review comments acknowledged**: Fetch all line-level comments with `gh api repos/{owner}/{repo}/pulls/{number}/comments` and verify every comment has either a 👍 reaction or a reply. If any are unacknowledged, go back to Step 9.
+
+**Do NOT proceed to Step 11 until all three checks pass.**
+
+## Step 11: User Approval and Merge
+
+1. **Notify the user**: Tell them the PR is ready for their review and approval
+2. **Wait for approval**: Do NOT merge until the user explicitly approves
+3. **If feedback given**: Make fixes, commit, push, and repeat from Step 4 (build, tests + browser validation)
+4. **If approved**: Proceed to merge with `gh pr merge --squash --delete-branch`
 
 **Exception**: For markdown-only PRs (`.md` files only), merge immediately without waiting for user approval.


### PR DESCRIPTION
## Summary

Fixes #630

Updates the `/execute-issues` and `/pr` Claude Code skills to prevent PRs from being merged with unchecked checkboxes or unacknowledged review comments.

## Changes

**`/pr` SKILL.md:**
- Split Step 10 into **Step 10: Pre-Merge Verification** (non-skippable) and **Step 11: User Approval and Merge**
- Step 10 now verifies: all PR checkboxes checked, all acceptance criteria checked, all review comments acknowledged
- Made the 👍 reaction requirement a prominent callout in Step 9

**`/execute-issues` SKILL.md:**
- Updated Step 10 override to reference Step 11 (approval only), preserving Step 10 (verification) as non-skippable
- Added explicit pre-merge verification step (Step 6) to sub-agent prompt template

## Test Plan

- [x] Changes are markdown-only (SKILL.md files) — no code tests needed
- [x] Reviewed both files for consistency in step numbering

## Context

PR #628 was merged with 3 unchecked test plan items, all acceptance criteria unchecked, and 2 Copilot review comments with no acknowledgment. These changes prevent that from happening again.

## Summary by Sourcery

Enforce stricter pre-merge verification in the PR and execute-issues skills to prevent merging with unchecked checklists or unacknowledged review comments.

Enhancements:
- Clarify and highlight the requirement to acknowledge every line-level review comment via reaction or reply in the /pr skill.
- Split the /pr flow into a non-skippable pre-merge verification step and a separate user approval and merge step, ensuring all checkboxes, acceptance criteria, and review comment acknowledgments are verified before merge.
- Update the /execute-issues skill to respect the new /pr step structure, keeping pre-merge verification mandatory while allowing autonomous merges to skip only the user-approval step.
- Add an explicit pre-merge verification phase to the /execute-issues sub-agent instructions and adjust step numbering accordingly.