### PR TITLE
Fix: correct service name, region, and project ID in docs

### DIFF
--- a/.claude/skills/postmortem/SKILL.md
+++ b/.claude/skills/postmortem/SKILL.md
@@ -42,8 +42,8 @@ If using Cloud Run, verify the deployed commit:
 
 ```bash
 # Get the deployed image tag (usually a commit SHA)
-gcloud run services describe praxis-note \
-  --region us-central1 \
+gcloud run services describe praxisnote \
+  --region australia-southeast1 \
   --format 'value(spec.template.spec.containers[0].image)'
 
 # Compare against the fix PR's merge commit
@@ -74,7 +74,7 @@ Query production logs to find the actual error pattern.
 ```bash
 # Query logs for errors on the affected endpoint
 gcloud logging read \
-  "resource.type=cloud_run_revision AND resource.labels.service_name=praxis-note AND httpRequest.status=404 AND httpRequest.requestUrl=~\"api/notes.*promote\"" \
+  "resource.type=cloud_run_revision AND resource.labels.service_name=praxisnote AND httpRequest.status=404 AND httpRequest.requestUrl=~\"api/notes.*promote\"" \
   --limit 50 \
   --format json \
   --freshness 7d

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,12 +66,12 @@ gcloud auth login
 
 3. **Set the project**:
 ```bash
-gcloud config set project praxis-note-438204
+gcloud config set project praxisnote-prod
 ```
 
 4. **Verify Cloud Run access**:
 ```bash
-gcloud run services describe praxis-note --region us-central1
+gcloud run services describe praxisnote --region australia-southeast1
 ```
 
 5. **Verify logging access**:

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Open http://localhost:4200. Use the mock auth toolbar at the bottom to log in (n
 **Optional API keys:**
 - **Anthropic** (AI meeting analysis): `dotnet user-secrets set "MeetingAnalysis:ApiKey" "sk-ant-..." --project src/PraxisNote.Web`
 - **Deepgram** (live transcription): `dotnet user-secrets set "Deepgram:ApiKey" "your-key" --project src/PraxisNote.Web`
-- **Google OAuth** (calendar sync): Set `Authentication__Google__ClientId` and `Authentication__Google__ClientSecret` env vars before `docker compose up`
+- **Google OAuth** (calendar sync): The dev Docker stack uses mock Google credentials by default. To enable real OAuth/calendar sync, update the `Authentication__Google__ClientId` and `Authentication__Google__ClientSecret` values for the `api` service in `docker-compose.yml` (or a compose override/env file)
 
 Without these keys, the app runs normally — you just won't get AI analysis, live transcripts, or calendar sync.
 


### PR DESCRIPTION
## Summary

Fixes #634

Addresses 6 unacknowledged Copilot review comments from PRs #627 and #629.

## Changes

- **postmortem SKILL.md**: `praxis-note` → `praxisnote`, `us-central1` → `australia-southeast1`
- **CONTRIBUTING.md**: `praxis-note-438204` → `praxisnote-prod`, same region fix
- **README.md**: Clarified Google OAuth env var override mechanism for Docker dev stack

## Test Plan

- [x] Markdown-only changes — no code tests needed
- [x] All original review comments acknowledged with 👍