### PR TITLE
feat: add Quick Reflect Mode for faster self-reflection (#296)

### DIFF
--- a/src/PraxisNote.Web/ClientApp/src/app/meetings/meeting-editor.page.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/meetings/meeting-editor.page.ts
@@ -21,6 +21,7 @@ import { TiptapEditorComponent } from '../notes/tiptap-editor.component';
 import { MeetingService } from './meeting.service';
 import { MeetingAnalysisComponent } from './meeting-analysis.component';
 import { MeetingReflectionComponent } from './meeting-reflection.component';
+import { QuickReflectComponent } from './quick-reflect.component';
 import { MeetingSectionComponent } from './meeting-section.component';
 import { MeetingDetailsSectionComponent } from './meeting-details-section.component';
 import { MeetingTranscriptSectionComponent } from './meeting-transcript-section.component';
@@ -55,6 +56,7 @@ interface DateOption {
     MeetingTranscriptSectionComponent,
     MeetingAnalysisComponent,
     MeetingReflectionComponent,
+    QuickReflectComponent,
     DeleteConfirmButtonComponent,
     ButtonModule,
     TiptapEditorComponent,
@@ -276,6 +278,16 @@ interface DateOption {
         }
       </main>
 
+      <!-- Quick Reflect Dialog -->
+      @if (currentMeeting()) {
+        <app-quick-reflect
+          [meeting]="currentMeeting()!"
+          [visible]="showQuickReflect()"
+          (visibleChange)="showQuickReflect.set($event)"
+          (onSave)="onQuickReflectSave()"
+        />
+      }
+
       <!-- Footer -->
       <footer class="footer">
         @if (currentMeeting()) {
@@ -368,6 +380,9 @@ export class MeetingEditorPage implements OnInit, AfterViewInit, OnDestroy {
 
   // Delete confirmation state
   readonly confirmingDelete = signal(false);
+
+  // Quick reflect state
+  readonly showQuickReflect = signal(false);
 
   // Form state
   readonly title = signal('');
@@ -537,6 +552,20 @@ export class MeetingEditorPage implements OnInit, AfterViewInit, OnDestroy {
         this.analysisSection()?.expand();
       }
       hadAnalysis = hasAnalysis;
+    });
+
+    // Auto-open quick reflect if navigated from toast action
+    effect(() => {
+      const meeting = this.currentMeeting();
+      if (meeting && this.route.snapshot.queryParams['openQuickReflect'] === 'true') {
+        this.showQuickReflect.set(true);
+        // Clear query param
+        this.router.navigate([], {
+          relativeTo: this.route,
+          queryParams: {},
+          replaceUrl: true,
+        });
+      }
     });
   }
 
@@ -1283,6 +1312,15 @@ export class MeetingEditorPage implements OnInit, AfterViewInit, OnDestroy {
       });
       this.router.navigate([this.sourceBreadcrumb().route ?? '/meetings']);
     }
+  }
+
+  openQuickReflect(): void {
+    this.showQuickReflect.set(true);
+  }
+
+  onQuickReflectSave(): void {
+    this.showQuickReflect.set(false);
+    this.meetingService.loadMeetings();
   }
 
   // --- Formatting helpers ---

--- a/src/PraxisNote.Web/ClientApp/src/app/meetings/meeting.model.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/meetings/meeting.model.ts
@@ -195,3 +195,86 @@ export function parseReflection(json: string | null): MeetingReflection | null {
     return null;
   }
 }
+
+// Quick Reflection Types
+export type EmojiLevel = 'low' | 'medium' | 'high';
+
+export interface QuickReflectionValue {
+  talkTime: EmojiLevel | null;
+  engagement: EmojiLevel | null;
+  tone: EmojiLevel | null;
+  interruptions: EmojiLevel | null;
+  freeformNote: string | null;
+}
+
+export interface QuickReflectionDimension {
+  id: 'talkTime' | 'engagement' | 'tone' | 'interruptions';
+  label: string;
+  emojis: {
+    low: { emoji: string; label: string };
+    medium: { emoji: string; label: string };
+    high: { emoji: string; label: string };
+  };
+}
+
+export const QUICK_REFLECT_DIMENSIONS: QuickReflectionDimension[] = [
+  {
+    id: 'talkTime',
+    label: 'Talk time',
+    emojis: {
+      low: { emoji: '🤐', label: 'Quiet' },
+      medium: { emoji: '😐', label: 'Balanced' },
+      high: { emoji: '🗣️', label: 'Dominated' },
+    },
+  },
+  {
+    id: 'engagement',
+    label: 'Engagement',
+    emojis: {
+      low: { emoji: '😴', label: 'Low' },
+      medium: { emoji: '😊', label: 'Engaged' },
+      high: { emoji: '🔥', label: 'Highly' },
+    },
+  },
+  {
+    id: 'tone',
+    label: 'Tone',
+    emojis: {
+      low: { emoji: '😠', label: 'Tense' },
+      medium: { emoji: '😐', label: 'Neutral' },
+      high: { emoji: '😊', label: 'Positive' },
+    },
+  },
+  {
+    id: 'interruptions',
+    label: 'Interruptions',
+    emojis: {
+      low: { emoji: '✅', label: 'None' },
+      medium: { emoji: '⚠️', label: 'Some' },
+      high: { emoji: '🚨', label: 'Frequent' },
+    },
+  },
+];
+
+/** Maps emoji level values to Johari classification format */
+export function mapQuickReflectToJohari(quick: QuickReflectionValue): {
+  selfAssessedTalkTime: number | null;
+  selfAssessedEngagement: string | null;
+  selfAssessedTone: string | null;
+  interruptionAwareness: string | null;
+} {
+  return {
+    selfAssessedTalkTime: quick.talkTime
+      ? quick.talkTime === 'low' ? 20 : quick.talkTime === 'medium' ? 50 : 80
+      : null,
+    selfAssessedEngagement: quick.engagement
+      ? quick.engagement === 'low' ? 'Disengaged' : quick.engagement === 'medium' ? 'Moderate' : 'Highly Engaged'
+      : null,
+    selfAssessedTone: quick.tone
+      ? quick.tone === 'low' ? 'Tense' : quick.tone === 'medium' ? 'Neutral' : 'Collaborative'
+      : null,
+    interruptionAwareness: quick.interruptions
+      ? quick.interruptions === 'low' ? 'No' : quick.interruptions === 'medium' ? 'Partially' : 'Yes'
+      : null,
+  };
+}

--- a/src/PraxisNote.Web/ClientApp/src/app/meetings/meeting.service.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/meetings/meeting.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, inject, signal, computed, DestroyRef } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { HttpClient } from '@angular/common/http';
+import { Router } from '@angular/router';
 import { Observable, timer, Subject, exhaustMap, takeUntil, filter, take, tap, catchError, throwError, EMPTY, of } from 'rxjs';
 import { Meeting, MeetingGroup, ActionItemStatus, PromoteActionItemResult, ReflectionPrompt, MeetingReflection } from './meeting.model';
 import { getLocalDateKey } from '../shared/date-utils';
@@ -16,6 +17,7 @@ interface PendingDeletion {
 export class MeetingService {
   private readonly http = inject(HttpClient);
   private readonly toast = inject(ToastService);
+  private readonly router = inject(Router);
   private readonly destroyRef = inject(DestroyRef);
 
   private readonly pendingDeletions = new Map<string, PendingDeletion>();
@@ -229,7 +231,19 @@ export class MeetingService {
             );
 
             if (meeting.status === 'Ready') {
-              this.toast.success({ summary: 'Analysis complete' });
+              const meetingTitle = meeting.title ?? 'Your meeting';
+              this.toast.success({
+                summary: 'Ready to reflect?',
+                detail: `"${meetingTitle}" analysis is done — takes ~15 sec`,
+                action: {
+                  label: 'Reflect now',
+                  callback: () => {
+                    this.router.navigate(['/meetings', id], {
+                      queryParams: { openQuickReflect: 'true' },
+                    });
+                  },
+                },
+              });
             } else if (meeting.status === 'Failed') {
               this.toast.error('Analysis failed');
             }

--- a/src/PraxisNote.Web/ClientApp/src/app/meetings/quick-reflect.component.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/meetings/quick-reflect.component.ts
@@ -1,0 +1,207 @@
+import { Component, computed, inject, input, output, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { DialogModule } from 'primeng/dialog';
+import {
+  Meeting,
+  MeetingReflection,
+  QUICK_REFLECT_DIMENSIONS,
+  QuickReflectionDimension,
+  QuickReflectionValue,
+  EmojiLevel,
+  mapQuickReflectToJohari,
+} from './meeting.model';
+import { MeetingService } from './meeting.service';
+
+@Component({
+  selector: 'app-quick-reflect',
+  imports: [CommonModule, DialogModule],
+  template: `
+    <p-dialog
+      [visible]="visible()"
+      (visibleChange)="visibleChange.emit($event)"
+      [modal]="true"
+      [draggable]="false"
+      [resizable]="false"
+      [dismissableMask]="true"
+      [closable]="true"
+      [style]="{ width: '30rem' }"
+      [breakpoints]="{ '640px': '95vw' }"
+      header="Quick Reflect"
+      [styleClass]="'quick-reflect-dialog'"
+    >
+      @if (completed()) {
+        <div class="p-6 text-center">
+          <div class="w-12 h-12 rounded-full mx-auto mb-3 flex items-center justify-center" style="background: rgba(163, 190, 140, 0.15);">
+            <i class="pi pi-check text-lg" style="color: #a3be8c;"></i>
+          </div>
+          <div class="text-sm font-medium" style="color: #a3be8c;">Reflected</div>
+          <div class="text-xs text-foreground-muted mt-1">Your insight was saved</div>
+        </div>
+      } @else {
+        <div class="space-y-4">
+          @for (dimension of dimensions; track dimension.id) {
+            <div>
+              <div class="text-xs font-medium text-foreground-secondary mb-2">{{ dimension.label }}</div>
+              <div class="flex gap-3">
+                @for (level of levels; track level) {
+                  <div class="flex flex-col items-center gap-1">
+                    <button
+                      type="button"
+                      class="emoji-btn"
+                      [class.selected]="values()[dimension.id] === level"
+                      (click)="selectEmoji(dimension.id, level)"
+                      [attr.aria-label]="dimension.label + ': ' + dimension.emojis[level].label"
+                    >
+                      {{ dimension.emojis[level].emoji }}
+                    </button>
+                    <span class="text-[10px] text-foreground-muted">{{ dimension.emojis[level].label }}</span>
+                  </div>
+                }
+              </div>
+            </div>
+          }
+
+          @if (!noteExpanded()) {
+            <button
+              type="button"
+              class="text-xs text-foreground-muted hover:text-foreground-secondary flex items-center gap-1"
+              (click)="toggleNoteExpanded()"
+            >
+              <i class="pi pi-plus text-[10px]"></i> Add a note (optional)
+            </button>
+          } @else {
+            <div>
+              <label class="text-xs font-medium text-foreground-secondary mb-1 block">Note (optional)</label>
+              <textarea
+                class="w-full text-sm p-2 rounded-md border border-border bg-surface"
+                [rows]="2"
+                [value]="freeformNote()"
+                (input)="freeformNote.set($any($event.target).value)"
+                placeholder="Additional thoughts..."
+              ></textarea>
+            </div>
+          }
+        </div>
+
+        <div class="flex items-center justify-between pt-4 border-t border-border mt-4">
+          <button
+            type="button"
+            class="text-xs text-foreground-muted hover:text-accent-foreground"
+            (click)="expandToFull()"
+          >
+            Expand to full reflection
+          </button>
+          <button
+            type="button"
+            class="px-4 py-1.5 text-sm text-white rounded-md"
+            style="background: var(--color-meeting-reflection-border);"
+            (click)="save()"
+          >
+            Save
+          </button>
+        </div>
+      }
+    </p-dialog>
+  `,
+  styles: [`
+    :host ::ng-deep .quick-reflect-dialog .p-dialog-content {
+      padding: 1.25rem;
+    }
+
+    .emoji-btn {
+      width: 48px;
+      height: 48px;
+      border-radius: 12px;
+      border: 2px solid var(--color-border);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 24px;
+      cursor: pointer;
+      transition: all 0.15s;
+      background: var(--color-bg-subtle);
+    }
+
+    .emoji-btn:hover {
+      border-color: var(--color-meeting-reflection-border);
+      transform: scale(1.08);
+    }
+
+    .emoji-btn.selected {
+      border-color: var(--color-meeting-reflection-border);
+      background: rgba(180, 142, 173, 0.15);
+      box-shadow: 0 0 0 2px rgba(180, 142, 173, 0.2);
+    }
+  `],
+})
+export class QuickReflectComponent {
+  readonly meeting = input.required<Meeting>();
+  readonly visible = input.required<boolean>();
+  readonly visibleChange = output<boolean>();
+  readonly onSave = output<void>();
+
+  private readonly meetingService = inject(MeetingService);
+
+  readonly dimensions = QUICK_REFLECT_DIMENSIONS;
+  readonly levels: EmojiLevel[] = ['low', 'medium', 'high'];
+  readonly values = signal<QuickReflectionValue>({
+    talkTime: null,
+    engagement: null,
+    tone: null,
+    interruptions: null,
+    freeformNote: null,
+  });
+  readonly freeformNote = signal('');
+  readonly noteExpanded = signal(false);
+  readonly completed = signal(false);
+
+  selectEmoji(dimensionId: string, level: EmojiLevel): void {
+    this.values.update(v => ({
+      ...v,
+      [dimensionId]: v[dimensionId as keyof QuickReflectionValue] === level ? null : level,
+    }));
+  }
+
+  toggleNoteExpanded(): void {
+    this.noteExpanded.update(v => !v);
+  }
+
+  expandToFull(): void {
+    this.visibleChange.emit(false);
+    // The meeting editor page will handle showing the full reflection component
+  }
+
+  save(): void {
+    const johariMapped = mapQuickReflectToJohari({
+      ...this.values(),
+      freeformNote: this.freeformNote().trim() || null,
+    });
+
+    const reflection: MeetingReflection = {
+      selfAssessedTalkTime: johariMapped.selfAssessedTalkTime,
+      selfAssessedEngagement: johariMapped.selfAssessedEngagement,
+      selfAssessedTone: johariMapped.selfAssessedTone,
+      interruptionAwareness: johariMapped.interruptionAwareness,
+      freeformReflection: this.freeformNote().trim() || null,
+      promptResponses: [],
+    };
+
+    this.meetingService.submitReflection(this.meeting().id, reflection);
+    this.completed.set(true);
+
+    setTimeout(() => {
+      this.visibleChange.emit(false);
+      this.onSave.emit();
+      this.completed.set(false);
+      this.values.set({
+        talkTime: null,
+        engagement: null,
+        tone: null,
+        interruptions: null,
+        freeformNote: null,
+      });
+      this.freeformNote.set('');
+      this.noteExpanded.set(false);
+    }, 1500);
+  }
+}

--- a/src/PraxisNote.Web/ClientApp/src/app/shared/sidebar/sidebar.component.html
+++ b/src/PraxisNote.Web/ClientApp/src/app/shared/sidebar/sidebar.component.html
@@ -58,7 +58,7 @@
     @for (item of navItems; track item.path) {
       <button
         type="button"
-        class="w-full group flex items-center h-9 text-sm rounded-lg"
+        class="w-full group flex items-center h-9 text-sm rounded-lg relative"
         [class.gap-3]="!collapsed()"
         [class.px-3]="!collapsed()"
         [class.text-left]="!collapsed()"
@@ -84,6 +84,13 @@
         ></i>
         @if (!collapsed()) {
           <span>{{ item.label }}</span>
+        }
+        @if (item.path === '/meetings' && hasUnreflectedMeetings()) {
+          <span
+            class="absolute w-1.5 h-1.5 rounded-full"
+            style="background: var(--color-meeting-reflection-border); top: 8px; left: 20px;"
+            [attr.aria-label]="'Unreflected meetings available'"
+          ></span>
         }
       </button>
     }
@@ -371,7 +378,7 @@
         @for (item of navItems; track item.path) {
           <button
             type="button"
-            class="w-full flex items-center gap-3 h-11 px-3 text-sm rounded-lg text-left"
+            class="w-full flex items-center gap-3 h-11 px-3 text-sm rounded-lg text-left relative"
             [class.font-medium]="isActive(item.path)"
             [class.text-foreground]="isActive(item.path)"
             [class.bg-accent]="isActive(item.path)"
@@ -389,6 +396,13 @@
               aria-hidden="true"
             ></i>
             <span>{{ item.label }}</span>
+            @if (item.path === '/meetings' && hasUnreflectedMeetings()) {
+              <span
+                class="absolute w-1.5 h-1.5 rounded-full"
+                style="background: var(--color-meeting-reflection-border); top: 12px; left: 20px;"
+                [attr.aria-label]="'Unreflected meetings available'"
+              ></span>
+            }
           </button>
         }
 

--- a/src/PraxisNote.Web/ClientApp/src/app/shared/sidebar/sidebar.component.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/shared/sidebar/sidebar.component.ts
@@ -8,6 +8,7 @@ import { MenuItem } from 'primeng/api';
 import { SidebarActivityService } from './sidebar-activity.service';
 import { SidebarService } from './sidebar.service';
 import { ProfileService } from '../../profiles/profile.service';
+import { MeetingService } from '../../meetings/meeting.service';
 import { DOCS_URL } from '../constants';
 
 interface NavItem {
@@ -94,6 +95,7 @@ export class SidebarComponent implements OnInit {
   protected readonly activity = inject(SidebarActivityService);
   private readonly sidebarService = inject(SidebarService);
   protected readonly profileService = inject(ProfileService);
+  private readonly meetingService = inject(MeetingService);
 
   readonly collapsed = this.sidebarService.collapsed;
   protected readonly docsUrl = DOCS_URL;
@@ -147,6 +149,15 @@ export class SidebarComponent implements OnInit {
     { path: '/tags', label: 'Tag Hub', icon: 'pi-tags', enabled: true },
     { path: '/insights', label: 'Insights', icon: 'pi-chart-line', enabled: true },
   ];
+
+  readonly hasUnreflectedMeetings = computed(() => {
+    const meetings = this.meetingService.meetings();
+    return meetings.some(m =>
+      (m.status === 'Ready' || m.status === 'Reviewed') &&
+      m.behavioralAnalysis !== null &&
+      m.reflectionData === null
+    );
+  });
 
   ngOnInit(): void {
     // Set initial path

--- a/tests/PraxisNote.E2E.Tests/smoke-tests/quick-reflect.spec.ts
+++ b/tests/PraxisNote.E2E.Tests/smoke-tests/quick-reflect.spec.ts
@@ -1,0 +1,194 @@
+import { test, expect, type Page } from '@playwright/test';
+import { seedTestUser } from '../helpers/db-reset';
+import { getMockAuthHeaders, MockUser } from '../helpers/mock-auth';
+
+// Use unique user suffix for this test file to avoid interference with parallel tests
+const USER_SUFFIX = 9;
+let testUser: MockUser;
+
+test.describe('Quick Reflect', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  test.beforeAll(async () => {
+    testUser = await seedTestUser(USER_SUFFIX);
+  });
+
+  test.beforeEach(async ({ request }) => {
+    // Clean up meetings before each test
+    const meetings = await request.get('/api/meetings', {
+      headers: getMockAuthHeaders(testUser),
+    });
+    const meetingList = await meetings.json();
+    for (const meeting of meetingList) {
+      await request.delete(`/api/meetings/${meeting.id}`, {
+        headers: getMockAuthHeaders(testUser),
+      });
+    }
+  });
+
+  test('can complete quick reflect with emoji selections', async ({ page, request }) => {
+    // Create a meeting with behavioral analysis
+    const createRes = await request.post('/api/meetings', {
+      headers: getMockAuthHeaders(testUser),
+      data: {
+        title: 'Test Meeting',
+        meetingDate: new Date().toISOString(),
+        transcriptContent: 'Sample transcript',
+        behavioralAnalysis: JSON.stringify({
+          speakingDynamics: {
+            talkTimeByParticipant: [{ participant: 'User', percentage: 50, duration: '5m' }],
+            interruptionPatterns: [],
+            questionVsStatementRatio: { 'User': 0.5 },
+          },
+          sentimentTone: {
+            participantSentiments: [{ participant: 'User', sentiment: 'positive', score: 0.8 }],
+            toneShifts: [],
+            emotionalIndicators: [],
+          },
+          communicationPatterns: {
+            overallClarity: 0.8,
+            followUpPatterns: [],
+            engagementLevels: [{ participant: 'User', level: 'high', indicators: [] }],
+          },
+          redFlags: [],
+        }),
+        status: 'Ready',
+      },
+    });
+    const meeting = await createRes.json();
+
+    await setupAuth(page, testUser);
+    await page.goto(`/meetings/${meeting.id}`);
+
+    // Wait for page to load
+    await expect(page.locator('h1, input[type="text"]')).toBeVisible({ timeout: 10000 });
+
+    // Navigate to meeting with quick reflect query param
+    await page.goto(`/meetings/${meeting.id}?openQuickReflect=true`);
+
+    // Wait for quick reflect dialog to open
+    const dialog = page.locator('.quick-reflect-dialog');
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+
+    // Verify all 4 dimensions are shown
+    await expect(page.getByText('Talk time')).toBeVisible();
+    await expect(page.getByText('Engagement')).toBeVisible();
+    await expect(page.getByText('Tone')).toBeVisible();
+    await expect(page.getByText('Interruptions')).toBeVisible();
+
+    // Select an emoji for each dimension (selecting the medium option)
+    const emojiButtons = page.locator('.emoji-btn');
+    await expect(emojiButtons).toHaveCount(12); // 4 dimensions × 3 levels
+
+    // Select medium option for each dimension (indices 1, 4, 7, 10)
+    await emojiButtons.nth(1).click(); // Talk time - medium
+    await emojiButtons.nth(4).click(); // Engagement - medium
+    await emojiButtons.nth(7).click(); // Tone - medium
+    await emojiButtons.nth(10).click(); // Interruptions - medium
+
+    // Verify selected state
+    await expect(emojiButtons.nth(1)).toHaveClass(/selected/);
+    await expect(emojiButtons.nth(4)).toHaveClass(/selected/);
+    await expect(emojiButtons.nth(7)).toHaveClass(/selected/);
+    await expect(emojiButtons.nth(10)).toHaveClass(/selected/);
+
+    // Click save button
+    const saveButton = page.getByRole('button', { name: 'Save' });
+    await expect(saveButton).toBeVisible();
+    await saveButton.click();
+
+    // Wait for completion state
+    await expect(page.getByText('Reflected')).toBeVisible({ timeout: 5000 });
+
+    // Dialog should auto-close after 1.5s
+    await expect(dialog).not.toBeVisible({ timeout: 3000 });
+
+    // Verify reflection was saved
+    const reflectionRes = await request.get(`/api/meetings/${meeting.id}`, {
+      headers: getMockAuthHeaders(testUser),
+    });
+    const updatedMeeting = await reflectionRes.json();
+    expect(updatedMeeting.reflectionData).toBeTruthy();
+
+    const reflection = JSON.parse(updatedMeeting.reflectionData);
+    expect(reflection.selfAssessedTalkTime).toBe(50);
+    expect(reflection.selfAssessedEngagement).toBe('Moderate');
+    expect(reflection.selfAssessedTone).toBe('Neutral');
+    expect(reflection.interruptionAwareness).toBe('Partially');
+  });
+
+  test('nav dot shows for unreflected meetings and disappears after reflection', async ({ page, request }) => {
+    // Create a meeting with behavioral analysis but no reflection
+    const createRes = await request.post('/api/meetings', {
+      headers: getMockAuthHeaders(testUser),
+      data: {
+        title: 'Unreflected Meeting',
+        meetingDate: new Date().toISOString(),
+        transcriptContent: 'Sample transcript',
+        behavioralAnalysis: JSON.stringify({
+          speakingDynamics: {
+            talkTimeByParticipant: [{ participant: 'User', percentage: 50, duration: '5m' }],
+            interruptionPatterns: [],
+            questionVsStatementRatio: { 'User': 0.5 },
+          },
+          sentimentTone: {
+            participantSentiments: [{ participant: 'User', sentiment: 'positive', score: 0.8 }],
+            toneShifts: [],
+            emotionalIndicators: [],
+          },
+          communicationPatterns: {
+            overallClarity: 0.8,
+            followUpPatterns: [],
+            engagementLevels: [{ participant: 'User', level: 'high', indicators: [] }],
+          },
+          redFlags: [],
+        }),
+        status: 'Ready',
+      },
+    });
+    const meeting = await createRes.json();
+
+    await setupAuth(page, testUser);
+    await page.goto('/meetings');
+
+    // Wait for meetings to load
+    await page.waitForTimeout(1000);
+
+    // Check for nav dot indicator on Meetings nav item
+    const meetingsNavButton = page.locator('nav button').filter({ hasText: 'Meetings' });
+    const navDot = meetingsNavButton.locator('span[aria-label="Unreflected meetings available"]');
+    await expect(navDot).toBeVisible({ timeout: 5000 });
+
+    // Navigate to meeting and complete quick reflect
+    await page.goto(`/meetings/${meeting.id}?openQuickReflect=true`);
+
+    // Wait for dialog
+    const dialog = page.locator('.quick-reflect-dialog');
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+
+    // Select emojis and save
+    const emojiButtons = page.locator('.emoji-btn');
+    await emojiButtons.nth(1).click();
+    await emojiButtons.nth(4).click();
+    await emojiButtons.nth(7).click();
+    await emojiButtons.nth(10).click();
+
+    const saveButton = page.getByRole('button', { name: 'Save' });
+    await saveButton.click();
+
+    // Wait for completion
+    await expect(page.getByText('Reflected')).toBeVisible({ timeout: 5000 });
+    await expect(dialog).not.toBeVisible({ timeout: 3000 });
+
+    // Go back to meetings page
+    await page.goto('/meetings');
+    await page.waitForTimeout(1000);
+
+    // Nav dot should be gone
+    await expect(navDot).not.toBeVisible();
+  });
+});
+
+async function setupAuth(page: Page, user: MockUser): Promise<void> {
+  await page.setExtraHTTPHeaders(getMockAuthHeaders(user));
+}


### PR DESCRIPTION
## Summary

Adds a simplified "quick reflect" mode that lets users complete a self-reflection in under 15 seconds using emoji scales, increasing reflection completion rates and Johari Window data.

## Changes

- **Quick Reflect Component** — new dialog with 4 emoji scales (Talk Time, Engagement, Tone, Interruptions), 3 levels each, optional freeform note
- **Post-Analysis Toast** — changed from generic "Analysis complete" to "Ready to reflect?" with inline "Reflect now" action button
- **Query Param Handler** — auto-opens quick reflect when navigating with `?openQuickReflect=true`
- **Nav Dot Indicator** — purple dot on Meetings sidebar item when unreflected meetings exist (desktop + mobile)
- **Johari Mapping** — emoji selections map directly to existing Johari Window classification fields
- **E2E Tests** — 2 smoke tests for quick reflect flow and nav dot visibility

## Files Changed
- `meeting.model.ts` — added QuickReflection types + mapQuickReflectToJohari()
- `quick-reflect.component.ts` — new component
- `meeting-editor.page.ts` — integrated dialog + query param handler
- `meeting.service.ts` — updated post-analysis toast with reflect action
- `sidebar.component.ts/html` — nav dot indicator
- `quick-reflect.spec.ts` — new E2E tests

## Test Plan
- [x] Build passes (npx ng build)
- [x] All 13 acceptance criteria verified against code
- [x] Issue checkboxes updated

Closes #296

Co-Authored-By: Claude <noreply@anthropic.com>

## Summary by Sourcery

Introduce a quick emoji-based meeting reflection flow and surface prompts for users to complete reflections after analysis.

New Features:
- Add a Quick Reflect dialog component that lets users record a brief emoji-based reflection with an optional note and maps it into existing Johari-style reflection fields.
- Trigger automatic opening of the quick reflect dialog when navigating to a meeting with the appropriate query parameter, including from a post-analysis toast action.
- Show a visual indicator on the Meetings navigation item when there are meetings with analysis but no reflection data.

Enhancements:
- Update the post-analysis toast copy to invite users to reflect immediately and deep-link them into the corresponding meeting with quick reflect pre-opened.

Tests:
- Add Playwright smoke tests covering completing a quick reflection via emoji selections and verifying the nav-dot indicator behavior for unreflected meetings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Quick Reflect feature enabling users to rapidly record meeting reflections using emoji-based ratings across four key dimensions: Talk Time, Engagement, Tone, and Interruptions
  * Added visual indicator badge in sidebar navigation to highlight meetings awaiting reflection
  * Quick Reflect dialog automatically launches after meeting analysis completes with a "Reflect now" action, streamlining the reflection workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->