### PR TITLE
chore: add EF Core LINQ translation guardrails from bug #642 post-mortem

### DIFF
--- a/.claude/skills/refine/SKILL.md
+++ b/.claude/skills/refine/SKILL.md
@@ -171,6 +171,22 @@ cat src/PraxisNote.Domain/Aggregates/<Entity>/<Entity>.cs
 - What patterns exist that should be followed
 - What optimistic update hooks exist on the frontend
 
+### Repository Method Patterns (REQUIRED for new repository methods)
+
+When writing a **new repository method**, always check existing repository implementations for established patterns before writing code. EF Core has LINQ translation limitations that are easy to get wrong.
+
+```bash
+# Find existing repository methods that do similar operations
+grep -r "Contains\|ToList\|ToHashSet\|ToLower" src/PraxisNote.Infrastructure/Persistence/Repositories/ --include="*.cs" -B 2 -A 5
+```
+
+**Common mistakes to avoid:**
+- `HashSet<T>.Contains()` is NOT translatable to SQL — use `List<T>.Contains()` (generates `IN (...)`)
+- `.ToLowerInvariant()` is NOT translatable — use `.ToLower()` (generates `LOWER()`)
+- JSON-backed properties (e.g., `TagIds` as `HashSet<Guid>`) cannot be queried with `.Contains()` in LINQ — must filter in-memory after loading
+
+**Reference:** See `MeetingRepository.cs:70` for the correct pattern. See bug #642 for what happens when these rules are violated.
+
 ### Third-Party UI Extensions
 
 When the plan involves integrating a UI library or extension, identify the actual DOM output by reading the library's source code or documentation. Do NOT assume standard HTML elements — many libraries (TipTap, ProseMirror, Slate, etc.) use custom NodeViews that render non-standard DOM structures. Include the actual DOM structure in the plan so CSS selectors, query selectors, and interaction logic are correct from the start.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,28 @@ When implementing a common pattern, use these real files as references instead o
 - **Style**: Primary constructors, Minimal APIs
 - **Database**: Entity Framework Core with PostgreSQL (all environments)
 
+### EF Core LINQ Translation (Common Pitfalls)
+
+EF Core translates LINQ to SQL. These C# expressions **cannot** be translated and will throw at runtime:
+
+```csharp
+// WRONG: HashSet.Contains() is NOT translatable
+var names = input.ToHashSet();
+query.Where(t => names.Contains(t.Name));  // Runtime error!
+
+// CORRECT: Use List<T>.Contains() — translates to SQL IN (...)
+var names = input.ToList();
+query.Where(t => names.Contains(t.Name));  // Works!
+
+// WRONG: .ToLowerInvariant() is NOT translatable
+query.Where(t => t.Name.ToLowerInvariant() == value);  // Runtime error!
+
+// CORRECT: Use .ToLower() — translates to SQL LOWER()
+query.Where(t => t.Name.ToLower() == value);  // Works!
+```
+
+**Reference:** See `MeetingRepository.cs:70` for the correct `.ToList()` + `.Contains()` pattern. Bug #642 was caused by violating these rules.
+
 ## Frontend (Angular v21)
 
 ### Core Principles


### PR DESCRIPTION
## Summary
- Adds EF Core LINQ translation pitfalls to CLAUDE.md (Backend section) with code examples
- Adds repository method pattern checks to the `/refine` skill exploration step
- Prevents future `HashSet.Contains()` and `.ToLowerInvariant()` LINQ translation errors

Follows from the bug #642 post-mortem analysis.

## Test plan
- [x] Markdown-only change — no runtime impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document EF Core LINQ translation pitfalls and add repository pattern guardrails to prevent repeat of bug #642.

Enhancements:
- Introduce a required repository method pattern check step in the refine skill to encourage reuse of proven EF Core patterns and avoid LINQ translation issues.

Documentation:
- Add backend documentation on common EF Core LINQ translation pitfalls with examples of supported and unsupported patterns.