### PR TITLE
fix: update Anthropic model name to claude-sonnet-4-6

### DIFF
--- a/src/PraxisNote.Application/Features/Meetings/MeetingAnalysisSettings.cs
+++ b/src/PraxisNote.Application/Features/Meetings/MeetingAnalysisSettings.cs
@@ -5,7 +5,7 @@ public class MeetingAnalysisSettings
     public const string SectionName = "MeetingAnalysis";
 
     public string ApiKey { get; set; } = "";
-    public string Model { get; set; } = "claude-sonnet-4-20250514";
+    public string Model { get; set; } = "claude-sonnet-4-6";
     public int MaxTokens { get; set; } = 4096;
     public int TimeoutSeconds { get; set; } = 120;
 }

--- a/src/PraxisNote.Web/appsettings.json
+++ b/src/PraxisNote.Web/appsettings.json
@@ -21,7 +21,7 @@
   },
   "MeetingAnalysis": {
     "ApiKey": "",
-    "Model": "claude-sonnet-4-20250514",
+    "Model": "claude-sonnet-4-6",
     "MaxTokens": 4096,
     "TimeoutSeconds": 120
   },


### PR DESCRIPTION
## Problem
The configured model `claude-sonnet-4-20250514` does not exist, causing all AI analysis (meeting analysis, transcript import, tag AI chat) to silently fail.

## Fix
Updated model name to `claude-sonnet-4-6` in:
- `appsettings.json`
- `MeetingAnalysisSettings.cs` default value

## Related
Part of epic #678 (BYOAI). This is a quick unblock while the bigger feature is planned.

## Summary by Sourcery

Bug Fixes:
- Correct the default meeting analysis model name in configuration and settings to prevent AI analysis features from failing due to a nonexistent model.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated meeting analysis model configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->