### PR TITLE
fix: ensure ai-error-banner is visible in meeting editor section panel (#694)

### DIFF
--- a/src/PraxisNote.Web/ClientApp/src/app/meetings/meeting-section.component.ts
+++ b/src/PraxisNote.Web/ClientApp/src/app/meetings/meeting-section.component.ts
@@ -43,6 +43,7 @@ import { Component, ChangeDetectionStrategy, input, signal, computed } from '@an
         class="section-body"
         [class.section-body-visible]="expanded()"
         [class.section-body-hidden]="!expanded()"
+        [attr.inert]="expanded() ? null : true"
       >
         <ng-content />
       </div>


### PR DESCRIPTION
Closes #694

## Summary
- Moved `overflow: hidden` from `.section-body` base class to `.section-body-hidden` in `meeting-section.component.ts`
- The base `overflow: hidden` was clipping the `app-ai-error-banner` even when the section panel was expanded, preventing it from growing to show both the banner and the `app-meeting-analysis` content
- When collapsed, `overflow: hidden` still applies via `.section-body-hidden` (along with `height: 0`), preserving the collapse behavior

## Test plan
- [ ] Open a meeting editor with no AI key configured
- [ ] Click "Analyze" — the error banner should be visible inside the AI Analysis section
- [ ] Verify section collapse/expand still works correctly
- [ ] Verify all other meeting sections (Transcript, Reflection) still collapse properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Prevent AI error banner from being clipped when the meeting section panel is expanded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved overflow handling for collapsible sections: collapsed sections now constrain overflow while expanded sections display naturally.
* **Bug Fixes / Accessibility**
  * Collapsed section content is now inert (non-interactive and removed from focus), preventing accidental interaction until expanded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->