### PR TITLE
fix: detect insufficient credits errors from AI providers

### DIFF
--- a/openspec/changes/archive/2026-04-03-improve-ai-credit-error-message/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-03-improve-ai-credit-error-message/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-03

--- a/openspec/changes/archive/2026-04-03-improve-ai-credit-error-message/design.md
+++ b/openspec/changes/archive/2026-04-03-improve-ai-credit-error-message/design.md
@@ -1,0 +1,64 @@
+## Context
+
+The app supports three AI providers (Anthropic, OpenAI, Gemini). Each has catch chains in both their `*TagAiChatService` and `*MeetingAnalyzer` classes that translate provider-specific exceptions into domain exceptions (`AiKeyInvalidException`, `AiRateLimitedException`, `AiProviderException`).
+
+Currently there is no domain exception for "key is valid but account has no credits." Each provider returns this condition differently:
+
+| Provider | Status | Detection signal | Current (wrong) mapping |
+|----------|--------|-----------------|------------------------|
+| Anthropic | 400 | `"credit balance is too low"` in message | `AiProviderException` ("Could not reach") |
+| OpenAI | 429 | `"insufficient_quota"` in message | `AiRateLimitedException` |
+| Gemini | 429 | `"quota"` / `"RESOURCE_EXHAUSTED"` in body | `AiRateLimitedException` |
+
+## Goals / Non-Goals
+
+**Goals:**
+- Users see a clear "insufficient credits" message instead of misleading network/rate-limit errors
+- All three providers are handled consistently
+- `ValidateAiKey` distinguishes "no credits" from "bad key" so the UI can guide users to their billing page
+
+**Non-Goals:**
+- Deep-linking to each provider's billing page (nice-to-have, not this change)
+- Distinguishing rate limits from quota exhaustion on Gemini (both are 429 + RESOURCE_EXHAUSTED — we'll treat all Gemini 429s with quota keywords as insufficient credits, since genuine rate limits are transient and retrying will clarify)
+- Changing the frontend UI beyond surfacing the new result field
+
+## Decisions
+
+### Decision 1: Message-sniffing in catch guards
+
+Detect insufficient credits by inspecting `ex.Message` (or `ex.InnerException.Message`) for known substrings. This is fragile if providers change their error messages, but:
+- Anthropic gives us no status code distinction (400 for both bad request and no credits)
+- OpenAI uses 429 for both rate limits and quota — only the message body differs
+- The alternative (parsing JSON error response bodies) would require catching the response before the SDK processes it, which is far more invasive
+
+**Mitigation:** Use broad substring matches (`"credit balance"`, `"insufficient_quota"`, `"quota"`) and log the full exception so we can update if providers change wording.
+
+### Decision 2: Catch order — credits before rate limits
+
+For OpenAI and Gemini, the insufficient-credits catch clause MUST appear **before** the existing rate-limit catch, since both share HTTP 429. The `when` guard on the credits clause will check the message substring; if it doesn't match, execution falls through to the rate-limit clause.
+
+```
+catch (ClientResultException ex) when (ex.Status == 429 && IsInsufficientQuota(ex))
+    → AiInsufficientCreditsException
+
+catch (ClientResultException ex) when (ex.Status == 429)
+    → AiRateLimitedException  (genuine rate limit)
+```
+
+### Decision 3: New exception lives in Application layer
+
+`AiInsufficientCreditsException` follows the same pattern as `AiKeyInvalidException` — it lives in `src/PraxisNote.Application/Features/UserAiKeys/AiProviderException.cs` alongside the other AI domain exceptions.
+
+### Decision 4: ValidateAiKey result gets `InsufficientCredits` field
+
+Add `bool InsufficientCredits = false` to the existing `Result` record. The endpoint already returns the result — the frontend can read the new field to show a targeted message. This is backward-compatible (defaults to `false`).
+
+## Risks / Trade-offs
+
+- **Message strings may change** → Mitigation: Use broad substrings, log full exceptions, add tests that document expected messages so breakage is caught early.
+- **Gemini ambiguity** → Gemini uses `RESOURCE_EXHAUSTED` for both rate limits and billing quota. We'll treat 429 + quota keywords as insufficient credits. If it's actually a transient rate limit, the user retries and it works — acceptable UX.
+- **Six files touched** → The same pattern is repeated across `*TagAiChatService` and `*MeetingAnalyzer` for each provider. This is mechanical but needs care to get catch ordering right in all six files.
+
+## Open Questions
+
+_(none — all resolved during exploration)_

--- a/openspec/changes/archive/2026-04-03-improve-ai-credit-error-message/proposal.md
+++ b/openspec/changes/archive/2026-04-03-improve-ai-credit-error-message/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+When an AI provider rejects a request due to insufficient credits/quota, the error is misreported to the user. Anthropic's "credit balance too low" (HTTP 400) is shown as "Could not reach Anthropic." OpenAI and Gemini return insufficient quota as HTTP 429, which we currently report as "rate limited" — telling users their key is valid when their account is actually empty.
+
+## What Changes
+
+- Add a new `AiInsufficientCreditsException` domain exception for billing/credit errors
+- **Anthropic**: Detect `"credit balance is too low"` in the `HttpRequestException.Message` (HTTP 400, no status code from SDK) and throw `AiInsufficientCreditsException` instead of generic provider error
+- **OpenAI**: Detect `"insufficient_quota"` in the `ClientResultException.Message` (HTTP 429) and throw `AiInsufficientCreditsException` instead of rate-limited
+- **Gemini**: Detect `"quota"` or billing-related keywords in `HttpRequestException.Message` (HTTP 429) and throw `AiInsufficientCreditsException` instead of rate-limited
+- Handle the new exception in `ValidateAiKey` so validation returns a clear "insufficient credits" result
+- Surface a user-friendly message in the API response/UI
+
+## Capabilities
+
+### New Capabilities
+- `ai-insufficient-credits`: Detect and surface provider billing/credit errors distinctly from auth failures, rate limits, and network errors across all three AI providers (Anthropic, OpenAI, Gemini)
+
+### Modified Capabilities
+_(none)_
+
+## Impact
+
+- `src/PraxisNote.Application/Features/UserAiKeys/AiProviderException.cs` — new `AiInsufficientCreditsException` class
+- `src/PraxisNote.Application/Features/UserAiKeys/ValidateAiKey.cs` — new catch clause + result field
+- `src/PraxisNote.Infrastructure/External/AnthropicTagAiChatService.cs` — detect credit error in catch chain
+- `src/PraxisNote.Infrastructure/External/AnthropicMeetingAnalyzer.cs` — detect credit error in catch chain
+- `src/PraxisNote.Infrastructure/External/OpenAiTagAiChatService.cs` — detect credit error (429 + insufficient_quota)
+- `src/PraxisNote.Infrastructure/External/OpenAiMeetingAnalyzer.cs` — detect credit error
+- `src/PraxisNote.Infrastructure/External/GeminiTagAiChatService.cs` — detect credit error (429 + quota keywords)
+- `src/PraxisNote.Infrastructure/External/GeminiMeetingAnalyzer.cs` — detect credit error
+- `tests/` — unit tests for the new exception paths

--- a/openspec/changes/archive/2026-04-03-improve-ai-credit-error-message/specs/ai-insufficient-credits/spec.md
+++ b/openspec/changes/archive/2026-04-03-improve-ai-credit-error-message/specs/ai-insufficient-credits/spec.md
@@ -1,0 +1,81 @@
+## ADDED Requirements
+
+### Requirement: Insufficient credits exception
+
+The system SHALL provide an `AiInsufficientCreditsException` domain exception that is distinct from `AiKeyInvalidException`, `AiRateLimitedException`, and `AiProviderException`.
+
+#### Scenario: Exception carries provider name
+
+- **WHEN** an `AiInsufficientCreditsException` is constructed with provider name "Anthropic"
+- **THEN** the `Provider` property SHALL equal "Anthropic"
+- **AND** the `Message` SHALL contain "insufficient credits"
+
+### Requirement: Anthropic credit error detection
+
+The system SHALL detect Anthropic's "credit balance is too low" error and throw `AiInsufficientCreditsException` instead of `AiProviderException`.
+
+#### Scenario: Anthropic returns credit balance error during streaming
+
+- **WHEN** the Anthropic SDK throws `HttpRequestException` with message containing "credit balance is too low"
+- **THEN** the system SHALL throw `AiInsufficientCreditsException` with provider "Anthropic"
+- **AND** the system SHALL NOT throw `AiProviderException` with "Could not reach Anthropic"
+
+#### Scenario: Anthropic returns credit balance error during meeting analysis
+
+- **WHEN** the Anthropic API returns HTTP 400 with message containing "credit balance is too low" during meeting analysis
+- **THEN** the system SHALL throw `AiInsufficientCreditsException` with provider "Anthropic"
+
+### Requirement: OpenAI credit error detection
+
+The system SHALL detect OpenAI's "insufficient_quota" error and throw `AiInsufficientCreditsException` instead of `AiRateLimitedException`.
+
+#### Scenario: OpenAI returns insufficient quota during streaming
+
+- **WHEN** the OpenAI SDK throws `ClientResultException` with status 429 and message containing "insufficient_quota"
+- **THEN** the system SHALL throw `AiInsufficientCreditsException` with provider "OpenAI"
+- **AND** the system SHALL NOT throw `AiRateLimitedException`
+
+#### Scenario: OpenAI returns insufficient quota during meeting analysis
+
+- **WHEN** the OpenAI SDK throws `ClientResultException` with status 429 and message containing "insufficient_quota"
+- **THEN** the system SHALL throw `AiInsufficientCreditsException` with provider "OpenAI"
+
+### Requirement: Gemini credit error detection
+
+The system SHALL detect Gemini's quota exhaustion error and throw `AiInsufficientCreditsException` instead of `AiRateLimitedException`.
+
+#### Scenario: Gemini returns quota exhaustion during streaming
+
+- **WHEN** the Gemini API returns HTTP 429 with response body containing "quota" or "RESOURCE_EXHAUSTED"
+- **THEN** the system SHALL throw `AiInsufficientCreditsException` with provider "Gemini"
+- **AND** the system SHALL NOT throw `AiRateLimitedException`
+
+#### Scenario: Gemini returns quota exhaustion during meeting analysis
+
+- **WHEN** the Gemini API returns HTTP 429 with response body containing "quota" or "RESOURCE_EXHAUSTED"
+- **THEN** the system SHALL throw `AiInsufficientCreditsException` with provider "Gemini"
+
+### Requirement: ValidateAiKey handles insufficient credits
+
+The `ValidateAiKey` handler SHALL catch `AiInsufficientCreditsException` and return a result that distinguishes it from invalid keys and rate limits.
+
+#### Scenario: Validation catches insufficient credits
+
+- **WHEN** key validation triggers `AiInsufficientCreditsException`
+- **THEN** the result SHALL have `Validated = false`
+- **AND** the result SHALL have `InsufficientCredits = true`
+
+#### Scenario: Validation does not confuse credits with invalid key
+
+- **WHEN** key validation triggers `AiKeyInvalidException`
+- **THEN** the result SHALL have `Validated = false`
+- **AND** the result SHALL have `InsufficientCredits = false`
+
+### Requirement: API surfaces insufficient credits to frontend
+
+The API endpoint for key validation SHALL return a distinct error message when the key is valid but has insufficient credits.
+
+#### Scenario: Endpoint returns insufficient credits response
+
+- **WHEN** the validation result has `InsufficientCredits = true`
+- **THEN** the API SHALL return HTTP 422 with a message indicating the key is valid but the account has insufficient credits

--- a/openspec/changes/archive/2026-04-03-improve-ai-credit-error-message/tasks.md
+++ b/openspec/changes/archive/2026-04-03-improve-ai-credit-error-message/tasks.md
@@ -1,0 +1,32 @@
+## 1. Domain Exception
+
+- [x] 1.1 Add `AiInsufficientCreditsException` to `AiProviderException.cs` following the same pattern as `AiKeyInvalidException` (Provider property, descriptive message)
+
+## 2. Anthropic Error Detection
+
+- [x] 2.1 Add catch clause in `AnthropicTagAiChatService.StreamResponseAsync` (both pre-stream and enumeration catch blocks) to detect "credit balance" in `HttpRequestException.Message` and throw `AiInsufficientCreditsException`
+- [x] 2.2 Add catch clause in `AnthropicMeetingAnalyzer` to detect "credit balance" in `HttpRequestException.Message` and throw `AiInsufficientCreditsException`
+
+## 3. OpenAI Error Detection
+
+- [x] 3.1 Add catch clause in `OpenAiTagAiChatService` (both pre-stream and enumeration catch blocks) before the existing 429 catch to detect "insufficient_quota" in `ClientResultException.Message` and throw `AiInsufficientCreditsException`
+- [x] 3.2 Add catch clause in `OpenAiMeetingAnalyzer` before the existing 429 catch to detect "insufficient_quota" and throw `AiInsufficientCreditsException`
+
+## 4. Gemini Error Detection
+
+- [x] 4.1 Add catch clause in `GeminiTagAiChatService` before the existing 429 catch to detect "quota" or "RESOURCE_EXHAUSTED" in response body and throw `AiInsufficientCreditsException`
+- [x] 4.2 Add catch clause in `GeminiMeetingAnalyzer` before the existing 429 catch to detect "quota" or "RESOURCE_EXHAUSTED" and throw `AiInsufficientCreditsException`
+
+## 5. ValidateAiKey Handler
+
+- [x] 5.1 Add `InsufficientCredits` field to `ValidateAiKey.Result` record (default `false`)
+- [x] 5.2 Add catch clause for `AiInsufficientCreditsException` returning `new Result(false, InsufficientCredits: true)`
+
+## 6. API Endpoint
+
+- [x] 6.1 Update the validate-key endpoint to return a distinct message when `InsufficientCredits` is true
+
+## 7. Tests
+
+- [x] 7.1 Add unit tests for `AiInsufficientCreditsException` construction
+- [x] 7.2 Add/update `ValidateAiKey` tests to cover the `AiInsufficientCreditsException` catch path

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,20 @@
+schema: spec-driven
+
+# Project context (optional)
+# This is shown to AI when creating artifacts.
+# Add your tech stack, conventions, style guides, domain knowledge, etc.
+# Example:
+#   context: |
+#     Tech stack: TypeScript, React, Node.js
+#     We use conventional commits
+#     Domain: e-commerce platform
+
+# Per-artifact rules (optional)
+# Add custom rules for specific artifacts.
+# Example:
+#   rules:
+#     proposal:
+#       - Keep proposals under 500 words
+#       - Always include a "Non-goals" section
+#     tasks:
+#       - Break tasks into chunks of max 2 hours

--- a/openspec/specs/ai-insufficient-credits/spec.md
+++ b/openspec/specs/ai-insufficient-credits/spec.md
@@ -1,7 +1,7 @@
 # ai-insufficient-credits Specification
 
 ## Purpose
-TBD - created by archiving change improve-ai-credit-error-message. Update Purpose after archive.
+Detect and surface insufficient-credits errors from AI providers (Anthropic, OpenAI, Gemini) as a distinct exception so the frontend can show a clear "top up your balance" message instead of a misleading "invalid key" error.
 ## Requirements
 ### Requirement: Insufficient credits exception
 

--- a/openspec/specs/ai-insufficient-credits/spec.md
+++ b/openspec/specs/ai-insufficient-credits/spec.md
@@ -1,0 +1,85 @@
+# ai-insufficient-credits Specification
+
+## Purpose
+TBD - created by archiving change improve-ai-credit-error-message. Update Purpose after archive.
+## Requirements
+### Requirement: Insufficient credits exception
+
+The system SHALL provide an `AiInsufficientCreditsException` domain exception that is distinct from `AiKeyInvalidException`, `AiRateLimitedException`, and `AiProviderException`.
+
+#### Scenario: Exception carries provider name
+
+- **WHEN** an `AiInsufficientCreditsException` is constructed with provider name "Anthropic"
+- **THEN** the `Provider` property SHALL equal "Anthropic"
+- **AND** the `Message` SHALL contain "insufficient credits"
+
+### Requirement: Anthropic credit error detection
+
+The system SHALL detect Anthropic's "credit balance is too low" error and throw `AiInsufficientCreditsException` instead of `AiProviderException`.
+
+#### Scenario: Anthropic returns credit balance error during streaming
+
+- **WHEN** the Anthropic SDK throws `HttpRequestException` with message containing "credit balance is too low"
+- **THEN** the system SHALL throw `AiInsufficientCreditsException` with provider "Anthropic"
+- **AND** the system SHALL NOT throw `AiProviderException` with "Could not reach Anthropic"
+
+#### Scenario: Anthropic returns credit balance error during meeting analysis
+
+- **WHEN** the Anthropic API returns HTTP 400 with message containing "credit balance is too low" during meeting analysis
+- **THEN** the system SHALL throw `AiInsufficientCreditsException` with provider "Anthropic"
+
+### Requirement: OpenAI credit error detection
+
+The system SHALL detect OpenAI's "insufficient_quota" error and throw `AiInsufficientCreditsException` instead of `AiRateLimitedException`.
+
+#### Scenario: OpenAI returns insufficient quota during streaming
+
+- **WHEN** the OpenAI SDK throws `ClientResultException` with status 429 and message containing "insufficient_quota"
+- **THEN** the system SHALL throw `AiInsufficientCreditsException` with provider "OpenAI"
+- **AND** the system SHALL NOT throw `AiRateLimitedException`
+
+#### Scenario: OpenAI returns insufficient quota during meeting analysis
+
+- **WHEN** the OpenAI SDK throws `ClientResultException` with status 429 and message containing "insufficient_quota"
+- **THEN** the system SHALL throw `AiInsufficientCreditsException` with provider "OpenAI"
+
+### Requirement: Gemini credit error detection
+
+The system SHALL detect Gemini's quota exhaustion error and throw `AiInsufficientCreditsException` instead of `AiRateLimitedException`.
+
+#### Scenario: Gemini returns quota exhaustion during streaming
+
+- **WHEN** the Gemini API returns HTTP 429 with response body containing "quota" or "RESOURCE_EXHAUSTED"
+- **THEN** the system SHALL throw `AiInsufficientCreditsException` with provider "Gemini"
+- **AND** the system SHALL NOT throw `AiRateLimitedException`
+
+#### Scenario: Gemini returns quota exhaustion during meeting analysis
+
+- **WHEN** the Gemini API returns HTTP 429 with response body containing "quota" or "RESOURCE_EXHAUSTED"
+- **THEN** the system SHALL throw `AiInsufficientCreditsException` with provider "Gemini"
+
+### Requirement: ValidateAiKey handles insufficient credits
+
+The `ValidateAiKey` handler SHALL catch `AiInsufficientCreditsException` and return a result that distinguishes it from invalid keys and rate limits.
+
+#### Scenario: Validation catches insufficient credits
+
+- **WHEN** key validation triggers `AiInsufficientCreditsException`
+- **THEN** the result SHALL have `Validated = false`
+- **AND** the result SHALL have `InsufficientCredits = true`
+
+#### Scenario: Validation does not confuse credits with invalid key
+
+- **WHEN** key validation triggers `AiKeyInvalidException`
+- **THEN** the result SHALL have `Validated = false`
+- **AND** the result SHALL have `InsufficientCredits = false`
+
+### Requirement: API surfaces insufficient credits to frontend
+
+The API endpoint for key validation SHALL return a distinct error message when the key is valid but has insufficient credits.
+
+#### Scenario: Endpoint returns insufficient credits response
+
+- **WHEN** the validation result has `InsufficientCredits = true`
+- **THEN** the API SHALL return HTTP 422 with a message indicating the key is valid but the account has insufficient credits
+

--- a/src/PraxisNote.Application/Features/UserAiKeys/AiProviderException.cs
+++ b/src/PraxisNote.Application/Features/UserAiKeys/AiProviderException.cs
@@ -24,6 +24,17 @@ public sealed class AiRateLimitedException : Exception
     }
 }
 
+public sealed class AiInsufficientCreditsException : Exception
+{
+    public string Provider { get; }
+
+    public AiInsufficientCreditsException(string provider)
+        : base($"Insufficient credits on {provider} account.")
+    {
+        Provider = provider;
+    }
+}
+
 public sealed class AiProviderException : Exception
 {
     public string Provider { get; }

--- a/src/PraxisNote.Application/Features/UserAiKeys/ValidateAiKey.cs
+++ b/src/PraxisNote.Application/Features/UserAiKeys/ValidateAiKey.cs
@@ -17,7 +17,7 @@ public sealed class ValidateAiKey(
 
     public record Command(AiProvider Provider, string ApiKey);
 
-    public record Result(bool Validated, bool RateLimited = false);
+    public record Result(bool Validated, bool RateLimited = false, bool InsufficientCredits = false);
 
     public async Task<Result> ExecuteAsync(Command command, CancellationToken cancellationToken = default)
     {
@@ -62,6 +62,12 @@ public sealed class ValidateAiKey(
             logger.LogWarning(ex, "AI key validation failed (network) for provider {Provider}: {Status}",
                 command.Provider, ex.StatusCode);
             return new Result(false);
+        }
+        catch (AiInsufficientCreditsException ex)
+        {
+            logger.LogInformation("AI key validation found insufficient credits for provider {Provider}",
+                command.Provider);
+            return new Result(false, InsufficientCredits: true);
         }
         catch (AiKeyInvalidException ex)
         {

--- a/src/PraxisNote.Infrastructure/External/AnthropicMeetingAnalyzer.cs
+++ b/src/PraxisNote.Infrastructure/External/AnthropicMeetingAnalyzer.cs
@@ -166,6 +166,11 @@ public sealed class AnthropicMeetingAnalyzer : IMeetingAnalyzer
             _logger.LogError(ex, "Provider error from {Provider}: {StatusCode}", "Anthropic", ex.StatusCode);
             throw new AiProviderException("Anthropic", "Anthropic returned an error. Try again shortly.", ex);
         }
+        catch (HttpRequestException ex) when (ex.Message.Contains("credit balance", StringComparison.OrdinalIgnoreCase))
+        {
+            _logger.LogWarning(ex, "Insufficient credits for {Provider}", "Anthropic");
+            throw new AiInsufficientCreditsException("Anthropic");
+        }
         catch (HttpRequestException ex)
         {
             _logger.LogError(ex, "Network error calling {Provider}", "Anthropic");
@@ -323,6 +328,11 @@ public sealed class AnthropicMeetingAnalyzer : IMeetingAnalyzer
             _logger.LogError(ex, "Provider error from {Provider}: {StatusCode}", "Anthropic", ex.StatusCode);
             throw new AiProviderException("Anthropic", "Anthropic returned an error. Try again shortly.", ex);
         }
+        catch (HttpRequestException ex) when (ex.Message.Contains("credit balance", StringComparison.OrdinalIgnoreCase))
+        {
+            _logger.LogWarning(ex, "Insufficient credits for {Provider}", "Anthropic");
+            throw new AiInsufficientCreditsException("Anthropic");
+        }
         catch (HttpRequestException ex)
         {
             _logger.LogError(ex, "Network error calling {Provider}", "Anthropic");
@@ -399,6 +409,11 @@ public sealed class AnthropicMeetingAnalyzer : IMeetingAnalyzer
         {
             _logger.LogError(ex, "Provider error from {Provider}: {StatusCode}", "Anthropic", ex.StatusCode);
             throw new AiProviderException("Anthropic", "Anthropic returned an error. Try again shortly.", ex);
+        }
+        catch (HttpRequestException ex) when (ex.Message.Contains("credit balance", StringComparison.OrdinalIgnoreCase))
+        {
+            _logger.LogWarning(ex, "Insufficient credits for {Provider}", "Anthropic");
+            throw new AiInsufficientCreditsException("Anthropic");
         }
         catch (HttpRequestException ex)
         {

--- a/src/PraxisNote.Infrastructure/External/AnthropicTagAiChatService.cs
+++ b/src/PraxisNote.Infrastructure/External/AnthropicTagAiChatService.cs
@@ -126,6 +126,11 @@ public sealed class AnthropicTagAiChatService : ITagAiChatService
             _logger.LogError(ex, "Timeout initializing stream with {Provider}", "Anthropic");
             throw new AiProviderException("Anthropic", "Anthropic is not responding. Try again shortly.", ex);
         }
+        catch (HttpRequestException ex) when (ex.Message.Contains("credit balance", StringComparison.OrdinalIgnoreCase))
+        {
+            _logger.LogWarning(ex, "Insufficient credits for {Provider}", "Anthropic");
+            throw new AiInsufficientCreditsException("Anthropic");
+        }
         catch (HttpRequestException ex)
         {
             _logger.LogError(ex, "Network error calling {Provider}", "Anthropic");
@@ -161,6 +166,11 @@ public sealed class AnthropicTagAiChatService : ITagAiChatService
                 {
                     _logger.LogError(ex, "Provider error from {Provider}: {StatusCode}", "Anthropic", ex.StatusCode);
                     throw new AiProviderException("Anthropic", "Anthropic returned an error. Try again shortly.", ex);
+                }
+                catch (HttpRequestException ex) when (ex.Message.Contains("credit balance", StringComparison.OrdinalIgnoreCase))
+                {
+                    _logger.LogWarning(ex, "Insufficient credits for {Provider}", "Anthropic");
+                    throw new AiInsufficientCreditsException("Anthropic");
                 }
                 catch (HttpRequestException ex)
                 {
@@ -252,6 +262,11 @@ public sealed class AnthropicTagAiChatService : ITagAiChatService
         {
             _logger.LogError(ex, "Provider error from {Provider}: {StatusCode}", "Anthropic", ex.StatusCode);
             throw new AiProviderException("Anthropic", "Anthropic returned an error. Try again shortly.", ex);
+        }
+        catch (HttpRequestException ex) when (ex.Message.Contains("credit balance", StringComparison.OrdinalIgnoreCase))
+        {
+            _logger.LogWarning(ex, "Insufficient credits for {Provider}", "Anthropic");
+            throw new AiInsufficientCreditsException("Anthropic");
         }
         catch (HttpRequestException ex)
         {

--- a/src/PraxisNote.Infrastructure/External/GeminiMeetingAnalyzer.cs
+++ b/src/PraxisNote.Infrastructure/External/GeminiMeetingAnalyzer.cs
@@ -110,7 +110,7 @@ public sealed class GeminiMeetingAnalyzer(
             {
                 var body = await response.Content.ReadAsStringAsync(cts.Token);
                 if (body.Contains("quota", StringComparison.OrdinalIgnoreCase)
-                    || body.Contains("RESOURCE_EXHAUSTED", StringComparison.Ordinal))
+                    || body.Contains("RESOURCE_EXHAUSTED", StringComparison.OrdinalIgnoreCase))
                 {
                     logger.LogWarning("Insufficient credits for {Provider}", "Gemini");
                     throw new AiInsufficientCreditsException("Gemini");

--- a/src/PraxisNote.Infrastructure/External/GeminiMeetingAnalyzer.cs
+++ b/src/PraxisNote.Infrastructure/External/GeminiMeetingAnalyzer.cs
@@ -108,6 +108,14 @@ public sealed class GeminiMeetingAnalyzer(
             using var response = await httpClient.SendAsync(request, cts.Token);
             if (response.StatusCode == HttpStatusCode.TooManyRequests)
             {
+                var body = await response.Content.ReadAsStringAsync(cts.Token);
+                if (body.Contains("quota", StringComparison.OrdinalIgnoreCase)
+                    || body.Contains("RESOURCE_EXHAUSTED", StringComparison.Ordinal))
+                {
+                    logger.LogWarning("Insufficient credits for {Provider}", "Gemini");
+                    throw new AiInsufficientCreditsException("Gemini");
+                }
+
                 var retryAfterSeconds = response.Headers.RetryAfter?.Delta is { } delta
                     ? (int)Math.Ceiling(delta.TotalSeconds)
                     : response.Headers.RetryAfter?.Date is { } date

--- a/src/PraxisNote.Infrastructure/External/GeminiTagAiChatService.cs
+++ b/src/PraxisNote.Infrastructure/External/GeminiTagAiChatService.cs
@@ -78,6 +78,15 @@ public sealed class GeminiTagAiChatService(
             response = await httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cts.Token);
             if (response.StatusCode == HttpStatusCode.TooManyRequests)
             {
+                var body = await response.Content.ReadAsStringAsync(cts.Token);
+                if (body.Contains("quota", StringComparison.OrdinalIgnoreCase)
+                    || body.Contains("RESOURCE_EXHAUSTED", StringComparison.Ordinal))
+                {
+                    response.Dispose();
+                    logger.LogWarning("Insufficient credits for {Provider}", "Gemini");
+                    throw new AiInsufficientCreditsException("Gemini");
+                }
+
                 var retryAfterSeconds = response.Headers.RetryAfter?.Delta is { } delta
                     ? (int)Math.Ceiling(delta.TotalSeconds)
                     : response.Headers.RetryAfter?.Date is { } date
@@ -205,6 +214,14 @@ public sealed class GeminiTagAiChatService(
             using var response = await httpClient.SendAsync(starterRequest, cts.Token);
             if (response.StatusCode == HttpStatusCode.TooManyRequests)
             {
+                var body = await response.Content.ReadAsStringAsync(cts.Token);
+                if (body.Contains("quota", StringComparison.OrdinalIgnoreCase)
+                    || body.Contains("RESOURCE_EXHAUSTED", StringComparison.Ordinal))
+                {
+                    logger.LogWarning("Insufficient credits for {Provider}", "Gemini");
+                    throw new AiInsufficientCreditsException("Gemini");
+                }
+
                 var retryAfterSeconds = response.Headers.RetryAfter?.Delta is { } delta
                     ? (int)Math.Ceiling(delta.TotalSeconds)
                     : response.Headers.RetryAfter?.Date is { } date

--- a/src/PraxisNote.Infrastructure/External/GeminiTagAiChatService.cs
+++ b/src/PraxisNote.Infrastructure/External/GeminiTagAiChatService.cs
@@ -80,7 +80,7 @@ public sealed class GeminiTagAiChatService(
             {
                 var body = await response.Content.ReadAsStringAsync(cts.Token);
                 if (body.Contains("quota", StringComparison.OrdinalIgnoreCase)
-                    || body.Contains("RESOURCE_EXHAUSTED", StringComparison.Ordinal))
+                    || body.Contains("RESOURCE_EXHAUSTED", StringComparison.OrdinalIgnoreCase))
                 {
                     response.Dispose();
                     logger.LogWarning("Insufficient credits for {Provider}", "Gemini");
@@ -216,7 +216,7 @@ public sealed class GeminiTagAiChatService(
             {
                 var body = await response.Content.ReadAsStringAsync(cts.Token);
                 if (body.Contains("quota", StringComparison.OrdinalIgnoreCase)
-                    || body.Contains("RESOURCE_EXHAUSTED", StringComparison.Ordinal))
+                    || body.Contains("RESOURCE_EXHAUSTED", StringComparison.OrdinalIgnoreCase))
                 {
                     logger.LogWarning("Insufficient credits for {Provider}", "Gemini");
                     throw new AiInsufficientCreditsException("Gemini");

--- a/src/PraxisNote.Infrastructure/External/OpenAiMeetingAnalyzer.cs
+++ b/src/PraxisNote.Infrastructure/External/OpenAiMeetingAnalyzer.cs
@@ -125,6 +125,11 @@ public sealed class OpenAiMeetingAnalyzer(
             logger.LogError(ex, "AI key rejected by {Provider}", "OpenAI");
             throw new AiKeyInvalidException("OpenAI");
         }
+        catch (ClientResultException ex) when (ex.Status == 429 && ex.Message.Contains("insufficient_quota", StringComparison.OrdinalIgnoreCase))
+        {
+            logger.LogWarning(ex, "Insufficient credits for {Provider}", "OpenAI");
+            throw new AiInsufficientCreditsException("OpenAI");
+        }
         catch (ClientResultException ex) when (ex.Status == 429)
         {
             logger.LogWarning("Rate limited by {Provider}", "OpenAI");

--- a/src/PraxisNote.Infrastructure/External/OpenAiTagAiChatService.cs
+++ b/src/PraxisNote.Infrastructure/External/OpenAiTagAiChatService.cs
@@ -67,6 +67,11 @@ public sealed class OpenAiTagAiChatService(
             logger.LogError(ex, "AI key rejected by {Provider}", "OpenAI");
             throw new AiKeyInvalidException("OpenAI");
         }
+        catch (ClientResultException ex) when (ex.Status == 429 && ex.Message.Contains("insufficient_quota", StringComparison.OrdinalIgnoreCase))
+        {
+            logger.LogWarning(ex, "Insufficient credits for {Provider}", "OpenAI");
+            throw new AiInsufficientCreditsException("OpenAI");
+        }
         catch (ClientResultException ex) when (ex.Status == 429)
         {
             logger.LogWarning("Rate limited by {Provider}", "OpenAI");
@@ -102,6 +107,11 @@ public sealed class OpenAiTagAiChatService(
                 {
                     logger.LogError(ex, "AI key rejected by {Provider}", "OpenAI");
                     throw new AiKeyInvalidException("OpenAI");
+                }
+                catch (ClientResultException ex) when (ex.Status == 429 && ex.Message.Contains("insufficient_quota", StringComparison.OrdinalIgnoreCase))
+                {
+                    logger.LogWarning(ex, "Insufficient credits for {Provider}", "OpenAI");
+                    throw new AiInsufficientCreditsException("OpenAI");
                 }
                 catch (ClientResultException ex) when (ex.Status == 429)
                 {
@@ -198,6 +208,11 @@ public sealed class OpenAiTagAiChatService(
         {
             logger.LogError(ex, "AI key rejected by {Provider}", "OpenAI");
             throw new AiKeyInvalidException("OpenAI");
+        }
+        catch (ClientResultException ex) when (ex.Status == 429 && ex.Message.Contains("insufficient_quota", StringComparison.OrdinalIgnoreCase))
+        {
+            logger.LogWarning(ex, "Insufficient credits for {Provider}", "OpenAI");
+            throw new AiInsufficientCreditsException("OpenAI");
         }
         catch (ClientResultException ex) when (ex.Status == 429)
         {

--- a/src/PraxisNote.Web/Endpoints/UserAiKeyEndpoints.cs
+++ b/src/PraxisNote.Web/Endpoints/UserAiKeyEndpoints.cs
@@ -91,6 +91,11 @@ public static class UserAiKeyEndpoints
             }
             catch (UserAiKeyNotFoundException) { /* No key stored — nothing to clean up */ }
 
+            if (validation.InsufficientCredits)
+            {
+                return Results.UnprocessableEntity(new { error = "ai_key_insufficient_credits", message = "Your API key is valid but your account has insufficient credits. Please top up your balance." });
+            }
+
             return Results.UnprocessableEntity(new { error = "ai_key_invalid" });
         }
 

--- a/src/PraxisNote.Web/Endpoints/UserAiKeyEndpoints.cs
+++ b/src/PraxisNote.Web/Endpoints/UserAiKeyEndpoints.cs
@@ -84,17 +84,18 @@ public static class UserAiKeyEndpoints
 
         if (!validation.Validated)
         {
+            if (validation.InsufficientCredits)
+            {
+                // Key is valid but account has no credits — do NOT delete the stored key
+                return Results.UnprocessableEntity(new { error = "ai_key_insufficient_credits", message = "Your API key is valid but your account has insufficient credits. Please top up your balance." });
+            }
+
             // Compensating delete — remove any previously stored key for this provider
             try
             {
                 await deleteKey.ExecuteAsync(new DeleteUserAiKey.Command(userId.Value, aiProvider), cancellationToken);
             }
             catch (UserAiKeyNotFoundException) { /* No key stored — nothing to clean up */ }
-
-            if (validation.InsufficientCredits)
-            {
-                return Results.UnprocessableEntity(new { error = "ai_key_insufficient_credits", message = "Your API key is valid but your account has insufficient credits. Please top up your balance." });
-            }
 
             return Results.UnprocessableEntity(new { error = "ai_key_invalid" });
         }

--- a/tests/PraxisNote.Application.Tests/UserAiKeys/UserAiKeyUseCaseTests.cs
+++ b/tests/PraxisNote.Application.Tests/UserAiKeys/UserAiKeyUseCaseTests.cs
@@ -424,7 +424,7 @@ public class UserAiKeyUseCaseTests
     }
 
     [Fact]
-    public async Task AiInsufficientCreditsException_CarriesProviderName()
+    public void AiInsufficientCreditsException_CarriesProviderName()
     {
         var ex = new AiInsufficientCreditsException("Anthropic");
 

--- a/tests/PraxisNote.Application.Tests/UserAiKeys/UserAiKeyUseCaseTests.cs
+++ b/tests/PraxisNote.Application.Tests/UserAiKeys/UserAiKeyUseCaseTests.cs
@@ -395,6 +395,44 @@ public class UserAiKeyUseCaseTests
     }
 
     [Fact]
+    public async Task Validate_AiInsufficientCreditsException_ReturnsInsufficientCredits()
+    {
+        var sut = CreateValidateAiKeySut(out _, out var chatService);
+        chatService.StreamResponseAsync(Arg.Any<TagChatContext>(), Arg.Any<string>(),
+                Arg.Any<IReadOnlyList<ChatMessage>>(), Arg.Any<CancellationToken>())
+            .Returns(ThrowingStream(new AiInsufficientCreditsException("Anthropic")));
+
+        var result = await sut.ExecuteAsync(new ValidateAiKey.Command(AiProvider.Anthropic, "sk-test"));
+
+        Assert.False(result.Validated);
+        Assert.True(result.InsufficientCredits);
+        Assert.False(result.RateLimited);
+    }
+
+    [Fact]
+    public async Task Validate_AiKeyInvalidException_DoesNotSetInsufficientCredits()
+    {
+        var sut = CreateValidateAiKeySut(out _, out var chatService);
+        chatService.StreamResponseAsync(Arg.Any<TagChatContext>(), Arg.Any<string>(),
+                Arg.Any<IReadOnlyList<ChatMessage>>(), Arg.Any<CancellationToken>())
+            .Returns(ThrowingStream(new AiKeyInvalidException("Anthropic")));
+
+        var result = await sut.ExecuteAsync(new ValidateAiKey.Command(AiProvider.Anthropic, "sk-bad"));
+
+        Assert.False(result.Validated);
+        Assert.False(result.InsufficientCredits);
+    }
+
+    [Fact]
+    public async Task AiInsufficientCreditsException_CarriesProviderName()
+    {
+        var ex = new AiInsufficientCreditsException("Anthropic");
+
+        Assert.Equal("Anthropic", ex.Provider);
+        Assert.Contains("insufficient credits", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task Validate_OperationCanceledException_Rethrows()
     {
         var sut = CreateValidateAiKeySut(out _, out var chatService);


### PR DESCRIPTION
## Summary
- Add `AiInsufficientCreditsException` domain exception to distinguish billing errors from auth failures and network errors
- **Anthropic**: Detect "credit balance is too low" (HTTP 400 misreported as "Could not reach Anthropic") and throw correct exception
- **OpenAI**: Detect "insufficient_quota" (HTTP 429 misreported as "rate limited") before the rate-limit catch
- **Gemini**: Detect "quota"/"RESOURCE_EXHAUSTED" (HTTP 429 misreported as "rate limited") by reading response body
- `ValidateAiKey` returns new `InsufficientCredits` flag so the API can return a targeted "top up your balance" message
- Add OpenSpec change artifacts (proposal, specs, design, tasks) as decision record

## Test plan
- [x] New `AiInsufficientCreditsException` unit test — provider name and message verified
- [x] `ValidateAiKey` catches `AiInsufficientCreditsException` and returns `InsufficientCredits: true`
- [x] `ValidateAiKey` does not set `InsufficientCredits` for `AiKeyInvalidException`
- [x] All 1,276 existing unit tests pass (761 domain + 503 application + 12 integration)
- [x] Build succeeds with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a dedicated insufficient-credits error path for AI providers and surface it through key validation and API responses.

New Features:
- Add AiInsufficientCreditsException domain exception to represent provider billing/credit exhaustion separately from invalid keys, rate limits, and generic provider errors.
- Extend ValidateAiKey result with an InsufficientCredits flag and return a distinct 422 response when a key is valid but the provider account lacks credits.

Bug Fixes:
- Correctly classify Anthropic credit-balance errors, OpenAI insufficient_quota responses, and Gemini quota exhaustion responses as insufficient-credits conditions instead of generic provider/network or rate-limit errors.

Enhancements:
- Update Anthropic, OpenAI, and Gemini chat and meeting analyzer services to detect provider-specific insufficient-credit signals and map them to the new domain exception.
- Add tests to ensure insufficient-credits scenarios are distinguished from invalid key and rate-limited cases and that the new exception carries provider information.

Documentation:
- Add OpenSpec specification, proposal, design, tasks, and configuration documenting the ai-insufficient-credits behaviour and decision record.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced AI provider error handling to distinguish between invalid API keys and insufficient account credits across Anthropic, Gemini, and OpenAI integrations.
  * Improved error messages now specifically indicate when credit issues are preventing AI functionality from working.

* **Bug Fixes**
  * API now returns more accurate error responses for credit-related failures, helping users quickly identify and resolve account balance issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->